### PR TITLE
send card tokenisation to checkout server in JOSE format

### DIFF
--- a/android-sdk/src/main/java/com/checkout/android_sdk/Response/JWKSResponse.kt
+++ b/android-sdk/src/main/java/com/checkout/android_sdk/Response/JWKSResponse.kt
@@ -1,0 +1,30 @@
+package com.checkout.android_sdk.Response
+
+import com.google.gson.annotations.SerializedName
+
+data class JWKSResponse(
+
+	@field:SerializedName("keys")
+	val keys: List<JWK?>
+)
+
+data class JWK(
+
+	@field:SerializedName("kty")
+	val kty: String,
+
+	@field:SerializedName("e")
+	val E: String,
+
+	@field:SerializedName("use")
+	val use: String,
+
+	@field:SerializedName("kid")
+	val kid: String,
+
+	@field:SerializedName("alg")
+	val alg: String,
+
+	@field:SerializedName("n")
+	val N: String
+)

--- a/android-sdk/src/main/java/com/checkout/android_sdk/Utils/Environment.java
+++ b/android-sdk/src/main/java/com/checkout/android_sdk/Utils/Environment.java
@@ -1,14 +1,24 @@
 package com.checkout.android_sdk.Utils;
 
 public enum Environment {
-    SANDBOX("https://api.sandbox.checkout.com/tokens", "https://api.sandbox.checkout.com/tokens"),
-    LIVE("https://api.checkout.com/tokens", "https://api.checkout.com/tokens");
+    SANDBOX(
+            "https://api.sandbox.checkout.com/tokens",
+            "https://api.sandbox.checkout.com/.well-known/content-encoding/jwks",
+            "https://api.sandbox.checkout.com/tokens"
+    ),
+    LIVE(
+            "https://api.checkout.com/tokens",
+            "https://api.checkout.com/.well-known/content-encoding/jwks",
+            "https://api.checkout.com/tokens"
+    );
 
     public final String token;
+    public final String jwks;
     public final String googlePay;
 
-    Environment(String token, String googlePay) {
+    Environment(String token, String jwks, String googlePay) {
         this.token = token;
+        this.jwks = jwks;
         this.googlePay = googlePay;
     }
 }

--- a/android-sdk/src/main/java/com/checkout/android_sdk/Utils/JWEEncrypt.kt
+++ b/android-sdk/src/main/java/com/checkout/android_sdk/Utils/JWEEncrypt.kt
@@ -1,0 +1,123 @@
+package com.checkout.android_sdk.Utils
+
+import android.util.Base64
+import org.json.JSONObject
+import java.math.BigInteger
+import java.security.AlgorithmParameters
+import java.security.KeyFactory
+import java.security.SecureRandom
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.MGF1ParameterSpec
+import java.security.spec.RSAPublicKeySpec
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.OAEPParameterSpec
+import javax.crypto.spec.PSource
+import javax.crypto.spec.SecretKeySpec
+
+
+fun ByteArray.encodeUrlSafeBase64(): String =
+        Base64.encodeToString(this, Base64.NO_PADDING or Base64.URL_SAFE or Base64.NO_WRAP)
+
+fun String.decodeUrlSafeBase64(): ByteArray =
+        Base64.decode(toByteArray(), Base64.NO_PADDING or Base64.URL_SAFE or Base64.NO_WRAP)
+
+fun jsonObject(vararg pairs: Pair<String, Any>) = JSONObject().apply {
+    pairs.forEach { put(it.first, it.second) }
+}
+
+object JWEEncrypt {
+
+    private const val IV_BIT_LENGTH = 96
+    private const val AUTH_TAG_BIT_LENGTH = 128
+    private const val AES_GCM_KEY_BIT_LENGTH = 256
+
+    @Throws(Throwable::class)
+    @JvmStatic
+    fun encrypt(
+            rsaPublicKeyModulus: String,
+            rsaPublicKeyExponent: String,
+            rsaKeyId: String,
+            payload: ByteArray
+    ): String {
+
+        val modulus = BigInteger(1, rsaPublicKeyModulus.decodeUrlSafeBase64())
+        val exponent = BigInteger(1, rsaPublicKeyExponent.decodeUrlSafeBase64())
+
+        val spec = RSAPublicKeySpec(modulus, exponent)
+
+        val rsaKeyFactory = KeyFactory.getInstance("RSA")
+        val rsaPublicKey = rsaKeyFactory.generatePublic(spec) as RSAPublicKey
+
+        val headerBytes = jsonObject(
+                "kid" to rsaKeyId,
+                "typ" to "JOSE",
+                "enc" to "A256GCM",
+                "alg" to "RSA-OAEP-256"
+        ).toString().toByteArray()
+        val encoderHeader = headerBytes.encodeUrlSafeBase64()
+
+        val cekKey = SecretKeySpec(
+                generateSecureBytes(AES_GCM_KEY_BIT_LENGTH),
+                "AES"
+        )
+
+        val gcmSpec = GCMParameterSpec(
+                AUTH_TAG_BIT_LENGTH,
+                generateSecureBytes(IV_BIT_LENGTH)
+        )
+
+        val cipherOutput = Cipher.getInstance("AES/GCM/NoPadding").run {
+            init(Cipher.ENCRYPT_MODE, cekKey, gcmSpec)
+            updateAAD(encoderHeader.toByteArray())
+            doFinal(payload)
+        }
+
+        val tagPos: Int = cipherOutput.size - (AUTH_TAG_BIT_LENGTH / 8)
+        val cipherTextBytes = subArray(cipherOutput, 0, tagPos)
+        val authTagBytes = subArray(cipherOutput, tagPos, (AUTH_TAG_BIT_LENGTH / 8))
+
+        // Encrypt the Content Encryption Key (CEK) with public RSA certificate
+        val encryptedCekKey = encryptContentEncryptionKey(
+                rsaPublicKey = rsaPublicKey,
+                cek = cekKey.encoded
+        )
+
+        val encodedEncryptedKey = encryptedCekKey.encodeUrlSafeBase64()
+        val encodedIv = gcmSpec.iv.encodeUrlSafeBase64()
+        val encodedCipherText = cipherTextBytes.encodeUrlSafeBase64()
+        val encodedAuth = authTagBytes.encodeUrlSafeBase64()
+
+        return "$encoderHeader.$encodedEncryptedKey.$encodedIv.$encodedCipherText.$encodedAuth"
+    }
+
+    private fun encryptContentEncryptionKey(
+            rsaPublicKey: RSAPublicKey,
+            cek: ByteArray
+    ): ByteArray {
+        val algParam = AlgorithmParameters.getInstance("OAEP")
+        algParam.init(
+                OAEPParameterSpec(
+                        "SHA-256",
+                        "MGF1",
+                        MGF1ParameterSpec.SHA256,
+                        PSource.PSpecified.DEFAULT
+                )
+        )
+        // Encrypt the Content Encryption Key (CEK) with public RSA certificate
+        return Cipher.getInstance("RSA/ECB/OAEPWithSHA-256AndMGF1Padding").run {
+            init(Cipher.ENCRYPT_MODE, rsaPublicKey, algParam)
+            doFinal(cek)
+        }
+    }
+
+    private fun generateSecureBytes(sizeInBits: Int) =
+            ByteArray(sizeInBits / 8).apply {
+                SecureRandom().nextBytes(this)
+            }
+
+    private fun subArray(byteArray: ByteArray, beginIndex: Int, length: Int) =
+            ByteArray(length).apply {
+                System.arraycopy(byteArray, beginIndex, this, 0, size)
+            }
+}

--- a/android-sdk/src/main/java/com/checkout/android_sdk/network/utils/TokenRequestor.kt
+++ b/android-sdk/src/main/java/com/checkout/android_sdk/network/utils/TokenRequestor.kt
@@ -1,5 +1,6 @@
 package com.checkout.android_sdk.network.utils
 
+import com.checkout.android_sdk.CheckoutAPIClient
 import com.checkout.android_sdk.CheckoutAPIClient.OnGooglePayTokenGenerated
 import com.checkout.android_sdk.CheckoutAPIClient.OnTokenGenerated
 
@@ -8,6 +9,7 @@ internal interface TokenRequestor {
     fun requestCardToken(
         correlationID: String?,
         requestBody: String,
+        joseRequest: Boolean,
         listener: OnTokenGenerated
     )
 
@@ -15,5 +17,9 @@ internal interface TokenRequestor {
         correlationID: String?,
         requestBody: String,
         listener: OnGooglePayTokenGenerated
+    )
+
+    fun fetchJWKS(
+        listener: CheckoutAPIClient.OnJWKSFetched
     )
 }


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes
Transfer card tokenisation details to checkout server in JOSH format instead of plain text

What types of changes does your code introduce to frames-android?

* [ ] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have added necessary documentation (if appropriate)

## Further comments
Currently, card tokenisation request sent to checkout.com in `applicaton/json` format which is plain text and vulnerable to attack, instead of that send the card details in encrypted format using JWE token with `RSA-OAEP-256` scheme and `AES256 GCM` symmetric encryption.
