### PR TITLE
Prepare for next version 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use the provided API to send sensitive data to the Checkout.com server and retri
 ## Requirements
 - Android minimum SDK 21
 
-> Compatibility verified with `targetSdk` versions 21 to 30
+> Compatibility verified with `targetSdk` versions 21 to 31
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Use the provided API to send sensitive data to the Checkout.com server and retri
  
 ## Requirements
 - Android minimum SDK 21
-- Target API level 30
+
+> Compatibility verified with `targetSdk` versions 21 to 30
 
 ## Demo
 
@@ -37,16 +38,16 @@ allprojects {
 }
 ```
 
-Add Frames SDK dependency to the module gradble file:
+Add Frames SDK dependency to the module gradle file:
 ```gradle
 // module gradle file
 dependencies {
- implementation 'com.github.checkout:frames-android:3.0.1'
+ implementation 'com.github.checkout:frames-android:<latest_version>'
 }
 ```
 
 
-> You can find more about the installation [here](https://jitpack.io/#checkout/frames-android)
+> You can find more about the installation and available versions [here](https://jitpack.io/#checkout/frames-android)
 
 > Please keep in mind that the Jitpack repository should to be added to the project gradle file while the dependency should be added in the module gradle file. [(see more about gradle files)](https://developer.android.com/studio/build)
 

--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id('kotlin-android')
     id('com.kezong.fat-aar')
 }
-ext.productVersion = "3.0.1"
+ext.productVersion = "3.1.0-SNAPSHOT"
 
 android {
     compileSdkVersion 30

--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -6,10 +6,9 @@ plugins {
 ext.productVersion = "3.1.0-SNAPSHOT"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "checkout-frames-proguard.pro"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "checkout.checkout_android"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
- Updated build version in preparation for the next release 3.1.0 (Marked -SNAPSHOT until formal release)
- Updated targetSdk to 31
- Updated README.md