### PR TITLE
PIMOB-1094: Shifted evenTheme properties to theme object.

### DIFF
--- a/android-sdk/src/main/java/com/checkout/android_sdk/Utils/CheckoutTheme.kt
+++ b/android-sdk/src/main/java/com/checkout/android_sdk/Utils/CheckoutTheme.kt
@@ -6,12 +6,12 @@ import android.util.TypedValue
 import com.checkout.android_sdk.R
 
 internal class CheckoutTheme(private val context: Context) : CheckoutThemeInterface {
-    private var colorPrimary: MutableMap<String, Any?>
-    private var colorAccent: MutableMap<String, Any?>
-    private var colorButtonNormal: MutableMap<String, Any?>
-    private var colorControlNormal: MutableMap<String, Any?>
-    private var textColorPrimary: MutableMap<String, Any?>
-    private var colorControlActivated: MutableMap<String, Any?>
+    private var colorPrimary: Map<String, Any?>
+    private var colorAccent: Map<String, Any?>
+    private var colorButtonNormal: Map<String, Any?>
+    private var colorControlNormal: Map<String, Any?>
+    private var textColorPrimary: Map<String, Any?>
+    private var colorControlActivated: Map<String, Any?>
 
     init {
         colorPrimary = geThemeColorResource(R.attr.colorPrimary)
@@ -35,27 +35,27 @@ internal class CheckoutTheme(private val context: Context) : CheckoutThemeInterf
         )
     }
 
-    override fun getColorPrimaryProperty(): MutableMap<String, Any?> {
+    override fun getColorPrimaryProperty(): Map<String, Any?> {
         return colorPrimary
     }
 
-    override fun getColorAccentProperty(): MutableMap<String, Any?> {
+    override fun getColorAccentProperty(): Map<String, Any?> {
         return colorAccent
     }
 
-    override fun getColorButtonNormalProperty(): MutableMap<String, Any?> {
+    override fun getColorButtonNormalProperty(): Map<String, Any?> {
         return colorButtonNormal
     }
 
-    override fun getTextColorPrimaryProperty(): MutableMap<String, Any?> {
+    override fun getTextColorPrimaryProperty(): Map<String, Any?> {
         return textColorPrimary
     }
 
-    override fun getColorControlActivatedProperty(): MutableMap<String, Any?> {
+    override fun getColorControlActivatedProperty(): Map<String, Any?> {
         return colorControlActivated
     }
 
-    override fun getColorControlNormalProperty(): MutableMap<String, Any?> {
+    override fun getColorControlNormalProperty(): Map<String, Any?> {
         return colorControlNormal
     }
 }

--- a/android-sdk/src/main/java/com/checkout/android_sdk/logging/FramesLoggingEventDataProvider.kt
+++ b/android-sdk/src/main/java/com/checkout/android_sdk/logging/FramesLoggingEventDataProvider.kt
@@ -10,12 +10,13 @@ object FramesLoggingEventDataProvider {
     internal fun logPaymentFormPresentedEvent(checkoutTheme: CheckoutTheme): FramesLoggingEvent {
         val eventData = mapOf(
             PaymentFormLanguageEventAttribute.locale to Locale.getDefault().toString(),
-            PaymentFormLanguageEventAttribute.colorPrimary to checkoutTheme.getColorPrimaryProperty(),
-            PaymentFormLanguageEventAttribute.colorAccent to checkoutTheme.getColorAccentProperty(),
-            PaymentFormLanguageEventAttribute.colorButtonNormal to checkoutTheme.getColorButtonNormalProperty(),
-            PaymentFormLanguageEventAttribute.colorControlNormal to checkoutTheme.getColorControlNormalProperty(),
-            PaymentFormLanguageEventAttribute.textColorPrimary to checkoutTheme.getTextColorPrimaryProperty(),
-            PaymentFormLanguageEventAttribute.colorControlActivated to checkoutTheme.getColorControlActivatedProperty(),
+            PaymentFormLanguageEventAttribute.theme to mapOf(
+                PaymentFormLanguageEventAttribute.colorPrimary to checkoutTheme.getColorPrimaryProperty(),
+                PaymentFormLanguageEventAttribute.colorAccent to checkoutTheme.getColorAccentProperty(),
+                PaymentFormLanguageEventAttribute.colorButtonNormal to checkoutTheme.getColorButtonNormalProperty(),
+                PaymentFormLanguageEventAttribute.colorControlNormal to checkoutTheme.getColorControlNormalProperty(),
+                PaymentFormLanguageEventAttribute.textColorPrimary to checkoutTheme.getTextColorPrimaryProperty(),
+                PaymentFormLanguageEventAttribute.colorControlActivated to checkoutTheme.getColorControlActivatedProperty())
         )
         return FramesLoggingEvent(
             MonitoringLevel.INFO,

--- a/android-sdk/src/main/java/com/checkout/android_sdk/logging/PaymentFormLanguageEventAttribute.kt
+++ b/android-sdk/src/main/java/com/checkout/android_sdk/logging/PaymentFormLanguageEventAttribute.kt
@@ -2,6 +2,7 @@ package com.checkout.android_sdk.logging
 
 internal object PaymentFormLanguageEventAttribute {
     const val locale = "locale"
+    const val theme = "theme"
     const val colorPrimary = "colorPrimary"
     const val colorAccent = "colorAccent"
     const val colorButtonNormal = "colorButtonNormal"

--- a/android-sdk/src/test/java/com/checkout/android_sdk/logging/FramesLoggingEventsTest.kt
+++ b/android-sdk/src/test/java/com/checkout/android_sdk/logging/FramesLoggingEventsTest.kt
@@ -47,36 +47,38 @@ class FramesLoggingEventsTest {
             FramesLoggingEventType.PAYMENT_FORM_PRESENTED,
             properties = mapOf(
                 PaymentFormLanguageEventAttribute.locale to "en_US",
-                PaymentFormLanguageEventAttribute.colorPrimary to
-                        mutableMapOf("alpha" to 255,
-                            "red" to 63,
-                            "green" to 81,
-                            "blue" to 181),
-                PaymentFormLanguageEventAttribute.colorAccent to
-                        mutableMapOf("alpha" to 255,
-                            "red" to 255,
-                            "green" to 64,
-                            "blue" to 129),
-                PaymentFormLanguageEventAttribute.colorButtonNormal to
-                        mutableMapOf("alpha" to 255,
-                            "red" to 214,
-                            "green" to 215,
-                            "blue" to 215),
-                PaymentFormLanguageEventAttribute.colorControlNormal to
-                        mutableMapOf("alpha" to 0,
-                            "red" to 0,
-                            "green" to 9,
-                            "blue" to 141),
-                PaymentFormLanguageEventAttribute.textColorPrimary to
-                        mutableMapOf("alpha" to 0,
-                            "red" to 0,
-                            "green" to 9,
-                            "blue" to 140),
-                PaymentFormLanguageEventAttribute.colorControlActivated to
-                        mutableMapOf("alpha" to 255,
-                            "red" to 255,
-                            "green" to 64,
-                            "blue" to 129),
+                PaymentFormLanguageEventAttribute.theme to mapOf(
+                    PaymentFormLanguageEventAttribute.colorPrimary to
+                            mutableMapOf("alpha" to 255,
+                                "red" to 63,
+                                "green" to 81,
+                                "blue" to 181),
+                    PaymentFormLanguageEventAttribute.colorAccent to
+                            mutableMapOf("alpha" to 255,
+                                "red" to 255,
+                                "green" to 64,
+                                "blue" to 129),
+                    PaymentFormLanguageEventAttribute.colorButtonNormal to
+                            mutableMapOf("alpha" to 255,
+                                "red" to 214,
+                                "green" to 215,
+                                "blue" to 215),
+                    PaymentFormLanguageEventAttribute.colorControlNormal to
+                            mutableMapOf("alpha" to 0,
+                                "red" to 0,
+                                "green" to 9,
+                                "blue" to 141),
+                    PaymentFormLanguageEventAttribute.textColorPrimary to
+                            mutableMapOf("alpha" to 0,
+                                "red" to 0,
+                                "green" to 9,
+                                "blue" to 140),
+                    PaymentFormLanguageEventAttribute.colorControlActivated to
+                            mutableMapOf("alpha" to 255,
+                                "red" to 255,
+                                "green" to 64,
+                                "blue" to 129),
+                )
             )
         )
     }


### PR DESCRIPTION
## Proposed changes

1 Shifted evenTheme properties to theme object
2 Improved Unit test to support  changes

## Types of changes

What types of changes does your code introduce to frames-android?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Lint and unit tests pass locally with my changes
* [X] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)

## Further comments
This feature is linked to [Log when CheckoutTheme values are changed](https://github.com/checkout/frames-android/pull/88). Additionally, this PR is opened for adding theme object to align event property to Logging specification.
