### PR TITLE
PIMOB-1485: Pay button is still enabled after you exit the screen and return to it again

### DIFF
--- a/frames/src/main/java/com/checkout/frames/screen/manager/PaymentFormStateManager.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/manager/PaymentFormStateManager.kt
@@ -30,6 +30,17 @@ internal class PaymentFormStateManager(
 
     override val isReadyForTokenization: StateFlow<Boolean> = provideIsReadyTokenizeFlow()
 
+    override fun resetPaymentState() {
+        cardNumber.value = ""
+        cardScheme.value = CardScheme.UNKNOWN
+        isCardNumberValid.value = false
+        expiryDate.value = ""
+        isExpiryDateValid.value = false
+        cvv.value = ""
+        isCvvValid.value = false
+        billingAddress.value = BillingAddress()
+    }
+
     @VisibleForTesting
     fun provideCardSchemeList(): List<CardScheme> = supportedCardSchemes.ifEmpty {
         CardScheme.fetchAllSupportedCardSchemes()

--- a/frames/src/main/java/com/checkout/frames/screen/manager/PaymentStateManager.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/manager/PaymentStateManager.kt
@@ -22,4 +22,6 @@ internal interface PaymentStateManager {
     val billingAddress: MutableStateFlow<BillingAddress>
 
     val isReadyForTokenization: StateFlow<Boolean>
+
+    fun resetPaymentState()
 }

--- a/frames/src/main/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModel.kt
@@ -13,6 +13,7 @@ import com.checkout.frames.di.base.Injector
 import com.checkout.frames.di.screen.PaymentDetailsViewModelSubComponent
 import com.checkout.frames.mapper.ImageStyleToClickableComposableImageMapper
 import com.checkout.frames.model.request.ImageStyleToClickableImageRequest
+import com.checkout.frames.screen.manager.PaymentStateManager
 import com.checkout.frames.style.component.base.TextLabelStyle
 import com.checkout.frames.style.screen.PaymentDetailsStyle
 import com.checkout.frames.style.view.TextLabelViewStyle
@@ -28,11 +29,16 @@ internal class PaymentDetailsViewModel @Inject constructor(
     private val clickableImageStyleMapper: ImageStyleToClickableComposableImageMapper,
     @Named(CLOSE_PAYMENT_FLOW_DI)
     private val closePaymentFlowUseCase: UseCase<Unit, Unit>,
+    private val paymentStateManager: PaymentStateManager,
     private val style: PaymentDetailsStyle
 ) : ViewModel() {
 
     val headerStyle: TextLabelViewStyle = provideHeaderViewStyle()
     val headerState: TextLabelState = provideHeaderState()
+
+    init {
+        paymentStateManager.resetPaymentState()
+    }
 
     private fun provideHeaderViewStyle(): TextLabelViewStyle = with(style.paymentDetailsHeaderStyle) {
         textLabelStyleMapper.map(

--- a/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
+++ b/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
@@ -1,7 +1,10 @@
 package com.checkout.frames.manager
 
 import com.checkout.base.model.CardScheme
+import com.checkout.base.model.Country
+import com.checkout.frames.screen.billingformdetails.models.BillingAddress
 import com.checkout.frames.screen.manager.PaymentFormStateManager
+import com.checkout.tokenization.model.Phone
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -26,5 +29,35 @@ internal class PaymentFormStateManagerTest {
         val expectedSupportedSchemes = CardScheme.fetchAllSupportedCardSchemes()
         // Then
         Assertions.assertEquals(paymentFormStateManager.supportedCardSchemeList, expectedSupportedSchemes)
+    }
+
+    @Test
+    fun `when reset of payment state is requested then payment state is returned to a default state`() {
+        // Given
+        val supportedSchemes = listOf(CardScheme.VISA, CardScheme.DISCOVER)
+        paymentFormStateManager = PaymentFormStateManager(supportedSchemes)
+        paymentFormStateManager.cvv.value = "123"
+        paymentFormStateManager.isCvvValid.value = true
+        paymentFormStateManager.cardNumber.value = "23423423423423423"
+        paymentFormStateManager.isCardNumberValid.value = true
+        paymentFormStateManager.expiryDate.value = "0234"
+        paymentFormStateManager.isExpiryDateValid.value = true
+        paymentFormStateManager.billingAddress.value = BillingAddress(
+            name = "name",
+            phone = Phone("+4332452452345234", Country.UNITED_KINGDOM)
+        )
+
+        // When
+        paymentFormStateManager.resetPaymentState()
+
+        // Then
+        Assertions.assertEquals(paymentFormStateManager.cvv.value, "")
+        Assertions.assertEquals(paymentFormStateManager.isCvvValid.value, false)
+        Assertions.assertEquals(paymentFormStateManager.cardNumber.value, "")
+        Assertions.assertEquals(paymentFormStateManager.isCardNumberValid.value, false)
+        Assertions.assertEquals(paymentFormStateManager.expiryDate.value, "")
+        Assertions.assertEquals(paymentFormStateManager.isExpiryDateValid.value, false)
+        Assertions.assertEquals(paymentFormStateManager.billingAddress.value, BillingAddress())
+        Assertions.assertEquals(paymentFormStateManager.supportedCardSchemeList, supportedSchemes)
     }
 }

--- a/frames/src/test/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModelTest.kt
@@ -9,6 +9,7 @@ import com.checkout.frames.mapper.TextLabelStyleToViewStyleMapper
 import com.checkout.frames.mapper.TextLabelStyleToStateMapper
 import com.checkout.frames.mapper.ImageStyleToComposableImageMapper
 import com.checkout.frames.mapper.ContainerStyleToModifierMapper
+import com.checkout.frames.screen.manager.PaymentStateManager
 import com.checkout.frames.style.component.base.TextLabelStyle
 import com.checkout.frames.style.screen.PaymentDetailsStyle
 import com.checkout.frames.style.view.TextLabelViewStyle
@@ -34,6 +35,9 @@ internal class PaymentDetailsViewModelTest {
     @RelaxedMockK
     lateinit var mockClosePaymentFlowUseCase: UseCase<Unit, Unit>
 
+    @RelaxedMockK
+    lateinit var mockPaymentStateManager: PaymentStateManager
+
     @SpyK
     lateinit var spyTextLabelStyleMapper: Mapper<TextLabelStyle, TextLabelViewStyle>
 
@@ -58,6 +62,7 @@ internal class PaymentDetailsViewModelTest {
             spyTextLabelStateMapper,
             spyClickableImageStyleMapper,
             mockClosePaymentFlowUseCase,
+            mockPaymentStateManager,
             style
         )
     }
@@ -87,6 +92,13 @@ internal class PaymentDetailsViewModelTest {
                 )
             }
         }
+
+    /** Functionality **/
+    @Test
+    fun `when view model is initialised then payment state is reset`() {
+        // Then
+        verify(exactly = 1) { mockPaymentStateManager.resetPaymentState() }
+    }
 
     private fun initMappers() {
         spyTextLabelStyleMapper = TextLabelStyleToViewStyleMapper(ContainerStyleToModifierMapper())


### PR DESCRIPTION
## Issue

[PIMOB-1485: Pay button is still enabled after you exit the screen and return to it again](https://checkout.atlassian.net/browse/PIMOB-1485)

## Proposed changes

Payment state reset was added.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x] Reviewers assigned
* [x] I have performed a self-review of my code and manual testing
* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered, etc...
