### PR TITLE
PIMOB-1504: Allow Checkout Android to be accessed publicly for headless merchants

### DIFF
--- a/checkout/src/main/java/com/checkout/CheckoutApiServiceFactory.kt
+++ b/checkout/src/main/java/com/checkout/CheckoutApiServiceFactory.kt
@@ -1,7 +1,6 @@
 package com.checkout
 
 import android.content.Context
-import androidx.annotation.RestrictTo
 import com.checkout.api.CheckoutApiClient
 import com.checkout.api.CheckoutApiService
 import com.checkout.base.model.Environment
@@ -27,7 +26,6 @@ import com.checkout.validation.validator.PhoneValidator
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public object CheckoutApiServiceFactory {
 
     public fun create(

--- a/checkout/src/main/java/com/checkout/base/usecase/UseCase.kt
+++ b/checkout/src/main/java/com/checkout/base/usecase/UseCase.kt
@@ -1,11 +1,8 @@
 package com.checkout.base.usecase
 
-import androidx.annotation.RestrictTo
-
 /**
  * Used for creation of use case
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public interface UseCase<D, T> {
     /**
      * Execute use case


### PR DESCRIPTION
## Issue

[PIMOB-1504: Allow Checkout Android to be accessed publicly for headless merchants](https://checkout.atlassian.net/browse/PIMOB-1504)

## Proposed changes

CheckoutApiServiceFactory is public and headless SDK can be used separately from UI-related functionality.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x] Reviewers assigned
* [x] I have performed a self-review of my code and manual testing
* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered, etc...
