### PR TITLE
[Frame] disable sending billingAddress if form is disabled or not edited

### DIFF
--- a/frames/src/main/java/com/checkout/frames/component/paybutton/PayButtonViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/component/paybutton/PayButtonViewModel.kt
@@ -63,9 +63,7 @@ internal class PayButtonViewModel @Inject constructor(
         .apply { modifier = modifier.fillMaxWidth() }
 
     private fun provideCardData(): Card = with(paymentStateManager) {
-        /**
-         * Get the BillingAddress value only if "the billing address is enabled" and "the address is edited".
-         */
+        // Get the BillingAddress value only if "the billing address is enabled" and "the address is edited".
         val address = billingAddress.value.takeIf { isBillingAddressEnabled.value && it.isEdited() }
 
         Card(

--- a/frames/src/main/java/com/checkout/frames/component/paybutton/PayButtonViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/component/paybutton/PayButtonViewModel.kt
@@ -10,11 +10,12 @@ import com.checkout.frames.di.base.InjectionClient
 import com.checkout.frames.di.base.Injector
 import com.checkout.frames.di.component.PayButtonViewModelSubComponent
 import com.checkout.frames.logging.PaymentFormEventType
+import com.checkout.frames.model.request.InternalCardTokenRequest
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress.Companion.isEdited
 import com.checkout.frames.screen.manager.PaymentStateManager
 import com.checkout.frames.style.component.PayButtonComponentStyle
 import com.checkout.frames.style.component.base.ButtonStyle
 import com.checkout.frames.style.view.InternalButtonViewStyle
-import com.checkout.frames.model.request.InternalCardTokenRequest
 import com.checkout.frames.utils.extensions.logEvent
 import com.checkout.frames.utils.extensions.toExpiryDate
 import com.checkout.frames.view.InternalButtonState
@@ -30,7 +31,7 @@ internal class PayButtonViewModel @Inject constructor(
     private val paymentStateManager: PaymentStateManager,
     private val cardTokenizationUseCase: UseCase<InternalCardTokenRequest, Unit>,
     private val buttonStyleMapper: Mapper<ButtonStyle, InternalButtonViewStyle>,
-    private val buttonStateMapper: Mapper<ButtonStyle, InternalButtonState>,
+    buttonStateMapper: Mapper<ButtonStyle, InternalButtonState>,
     private val logger: Logger<LoggingEvent>
 ) : ViewModel() {
 
@@ -62,14 +63,18 @@ internal class PayButtonViewModel @Inject constructor(
         .apply { modifier = modifier.fillMaxWidth() }
 
     private fun provideCardData(): Card = with(paymentStateManager) {
-        val billingAddress = billingAddress.value
+        /**
+         * Get the BillingAddress value only if "the billing address is enabled" and "the address is edited".
+         */
+        val address = billingAddress.value.takeIf { isBillingAddressEnabled.value && it.isEdited() }
+
         Card(
             expiryDate.value.toExpiryDate(),
-            billingAddress.name,
+            address?.name,
             cardNumber.value,
             cvv.value,
-            billingAddress.address,
-            billingAddress.phone
+            address?.address,
+            address?.phone
         )
     }
 

--- a/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
@@ -1,15 +1,14 @@
 package com.checkout.frames.screen.billingaddress.billingaddressdetails.models
 
 import com.checkout.base.model.Country
-import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress.Companion.DEFAULT_BILLING_ADDRESS
 import com.checkout.tokenization.model.Address
 import com.checkout.tokenization.model.Phone
-import java.util.*
+import java.util.Locale
 
 internal data class BillingAddress(
     val name: String? = null,
     val address: Address? = null,
-    var phone: Phone? = null,
+    var phone: Phone? = null
 ) {
     internal constructor() : this(
         "",

--- a/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
@@ -18,9 +18,7 @@ internal data class BillingAddress(
     internal companion object {
         internal val DEFAULT_BILLING_ADDRESS by lazy { BillingAddress() }
 
-        /**
-         * Whether the [BillingAddress] has been edited or same as the default one.
-         */
+        // Whether the [BillingAddress] has been edited or same as the default one.
         internal fun BillingAddress.isEdited() = (name == DEFAULT_BILLING_ADDRESS.name &&
                 address?.addressLine1 == DEFAULT_BILLING_ADDRESS.address?.addressLine1 &&
                 address?.addressLine2 == DEFAULT_BILLING_ADDRESS.address?.addressLine2 &&

--- a/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
@@ -1,17 +1,34 @@
 package com.checkout.frames.screen.billingaddress.billingaddressdetails.models
 
 import com.checkout.base.model.Country
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress.Companion.DEFAULT_BILLING_ADDRESS
 import com.checkout.tokenization.model.Address
 import com.checkout.tokenization.model.Phone
-import java.util.Locale
+import java.util.*
 
 internal data class BillingAddress(
     val name: String? = null,
     val address: Address? = null,
-    var phone: Phone? = null
+    var phone: Phone? = null,
 ) {
     internal constructor() : this(
         "",
         Address("", "", "", "", "", Country.from(Locale.getDefault().country))
     )
+
+    internal companion object {
+        internal val DEFAULT_BILLING_ADDRESS by lazy { BillingAddress() }
+
+        /**
+         * Whether the [BillingAddress] has been edited or same as the default one.
+         */
+        internal fun BillingAddress.isEdited() = (name == DEFAULT_BILLING_ADDRESS.name &&
+                address?.addressLine1 == DEFAULT_BILLING_ADDRESS.address?.addressLine1 &&
+                address?.addressLine2 == DEFAULT_BILLING_ADDRESS.address?.addressLine2 &&
+                address?.city == DEFAULT_BILLING_ADDRESS.address?.city &&
+                address?.state == DEFAULT_BILLING_ADDRESS.address?.state &&
+                address?.zip == DEFAULT_BILLING_ADDRESS.address?.zip &&
+                address?.country == DEFAULT_BILLING_ADDRESS.address?.country &&
+                phone == DEFAULT_BILLING_ADDRESS.phone).not()
+    }
 }

--- a/frames/src/main/java/com/checkout/frames/screen/manager/PaymentFormStateManager.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/manager/PaymentFormStateManager.kt
@@ -26,6 +26,7 @@ internal class PaymentFormStateManager(
 
     override val billingAddress: MutableStateFlow<BillingAddress> = MutableStateFlow(BillingAddress())
     override val isBillingAddressValid: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    override val isBillingAddressEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     override val supportedCardSchemeList = provideCardSchemeList()
 
@@ -33,7 +34,8 @@ internal class PaymentFormStateManager(
 
     override fun resetPaymentState(
         isCvvValid: Boolean,
-        isBillingAddressValid: Boolean
+        isBillingAddressValid: Boolean,
+        isBillingAddressEnabled: Boolean,
     ) {
         cardNumber.value = ""
         cardScheme.value = CardScheme.UNKNOWN
@@ -44,6 +46,7 @@ internal class PaymentFormStateManager(
         this.isCvvValid.value = isCvvValid
         billingAddress.value = BillingAddress()
         this.isBillingAddressValid.value = isBillingAddressValid
+        this.isBillingAddressEnabled.value = isBillingAddressEnabled
     }
 
     @VisibleForTesting

--- a/frames/src/main/java/com/checkout/frames/screen/manager/PaymentStateManager.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/manager/PaymentStateManager.kt
@@ -21,11 +21,14 @@ internal interface PaymentStateManager {
 
     val billingAddress: MutableStateFlow<BillingAddress>
     val isBillingAddressValid: MutableStateFlow<Boolean>
+    // Whether the billing address form is enabled or set to null
+    val isBillingAddressEnabled: MutableStateFlow<Boolean>
 
     val isReadyForTokenization: StateFlow<Boolean>
 
     fun resetPaymentState(
         isCvvValid: Boolean,
-        isBillingAddressValid: Boolean
+        isBillingAddressValid: Boolean,
+        isBillingAddressEnabled: Boolean,
     )
 }

--- a/frames/src/main/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModel.kt
@@ -35,11 +35,11 @@ internal class PaymentDetailsViewModel @Inject constructor(
     val componentProvider: ComponentProvider,
     private val textLabelStyleMapper: Mapper<TextLabelStyle, TextLabelViewStyle>,
     private val textLabelStateMapper: Mapper<TextLabelStyle?, TextLabelState>,
-    private val containerMapper: Mapper<ContainerStyle, Modifier>,
+    containerMapper: Mapper<ContainerStyle, Modifier>,
     private val clickableImageStyleMapper: ImageStyleToClickableComposableImageMapper,
     @Named(CLOSE_PAYMENT_FLOW_DI)
     private val closePaymentFlowUseCase: UseCase<Unit, Unit>,
-    private val paymentStateManager: PaymentStateManager,
+    paymentStateManager: PaymentStateManager,
     private val logger: Logger<LoggingEvent>,
     private val style: PaymentDetailsStyle
 ) : ViewModel() {
@@ -51,7 +51,12 @@ internal class PaymentDetailsViewModel @Inject constructor(
     init {
         val isCvvValidByDefault = style.cvvStyle == null
         val isBillingAddressValidByDefault = style.addressSummaryStyle?.isOptional ?: true
-        paymentStateManager.resetPaymentState(isCvvValidByDefault, isBillingAddressValidByDefault)
+        val isBillingAddressValidEnabled = style.addressSummaryStyle != null
+        paymentStateManager.resetPaymentState(
+            isCvvValidByDefault,
+            isBillingAddressValidByDefault,
+            isBillingAddressValidEnabled
+        )
         logger.logEventWithLocale(PaymentFormEventType.PRESENTED)
     }
 

--- a/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
+++ b/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
@@ -40,7 +40,7 @@ internal class PaymentFormStateManagerTest {
     @ParameterizedTest(
         name = "When reset of payment state is requested with: " +
                 "isCvvValid = {0} and isBillingAddressValid = {1}; " +
-                "Then default cvv isValid state = {0} and address isValid state = {1}"
+                "Then default cvv isValid state = {0}, address isValid state = {1} and address isEnabled state = {2}"
     )
     @MethodSource("resetArguments")
     fun `when reset of payment state is requested then payment state is returned to a default state`(
@@ -84,10 +84,14 @@ internal class PaymentFormStateManagerTest {
         @RequiresApi(Build.VERSION_CODES.N)
         @JvmStatic
         fun resetArguments(): Stream<Arguments> = Stream.of(
-            Arguments.of(false, false),
-            Arguments.of(true, false),
-            Arguments.of(false, true),
-            Arguments.of(true, true)
+            Arguments.of(false, false, true),
+            Arguments.of(true, false, true),
+            Arguments.of(false, true, true),
+            Arguments.of(true, true, true),
+            Arguments.of(false, false, false),
+            Arguments.of(true, false, false),
+            Arguments.of(false, true, false),
+            Arguments.of(true, true, false),
         )
     }
 }

--- a/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
+++ b/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
@@ -45,7 +45,8 @@ internal class PaymentFormStateManagerTest {
     @MethodSource("resetArguments")
     fun `when reset of payment state is requested then payment state is returned to a default state`(
         isCvvValid: Boolean,
-        isBillingAddressValid: Boolean
+        isBillingAddressValid: Boolean,
+        isBillingAddressEnabled: Boolean,
     ) {
         // Given
         val supportedSchemes = listOf(CardScheme.VISA, CardScheme.DISCOVER)
@@ -61,9 +62,10 @@ internal class PaymentFormStateManagerTest {
             phone = Phone("+4332452452345234", Country.UNITED_KINGDOM)
         )
         paymentFormStateManager.isBillingAddressValid.value = !isBillingAddressValid
+        paymentFormStateManager.isBillingAddressEnabled.value = !isBillingAddressEnabled
 
         // When
-        paymentFormStateManager.resetPaymentState(isCvvValid, isBillingAddressValid)
+        paymentFormStateManager.resetPaymentState(isCvvValid, isBillingAddressValid, isBillingAddressEnabled)
 
         // Then
         Assertions.assertEquals(paymentFormStateManager.cvv.value, "")
@@ -74,6 +76,7 @@ internal class PaymentFormStateManagerTest {
         Assertions.assertEquals(paymentFormStateManager.isExpiryDateValid.value, false)
         Assertions.assertEquals(paymentFormStateManager.billingAddress.value, BillingAddress())
         Assertions.assertEquals(paymentFormStateManager.isBillingAddressValid.value, isBillingAddressValid)
+        Assertions.assertEquals(paymentFormStateManager.isBillingAddressEnabled.value, isBillingAddressEnabled)
         Assertions.assertEquals(paymentFormStateManager.supportedCardSchemeList, supportedSchemes)
     }
 

--- a/frames/src/test/java/com/checkout/frames/screen/billingaddressdetails/models/BillingAddressTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/billingaddressdetails/models/BillingAddressTest.kt
@@ -1,0 +1,60 @@
+package com.checkout.frames.screen.billingaddressdetails.models
+
+import com.checkout.base.model.Country
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress.Companion.DEFAULT_BILLING_ADDRESS
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress.Companion.isEdited
+import com.checkout.tokenization.model.Address
+import com.checkout.tokenization.model.Phone
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+
+internal class BillingAddressTest {
+    @Test
+    fun `A default BillingAddress should not be edited`() = assertFalse(BillingAddress().isEdited())
+
+    @Test
+    fun `If BillingAddress name is edited then edited() should return true`() =
+        assertTrue(BillingAddress(name = "NAME").isEdited())
+
+    @Test
+    fun `If BillingAddress phone is edited then edited() should return true`() =
+        assertTrue(BillingAddress(phone = Phone(number = "1234", Country.AFGHANISTAN)).isEdited())
+
+    @Test
+    fun `If BillingAddress addressLine1 is edited then edited() should return true`() =
+        assertTrue(BillingAddress(address = buildBillingAddress(addressLine1 = "addressLine1")).isEdited())
+
+    @Test
+    fun `If BillingAddress addressLine2 is edited then edited() should return true`() =
+        assertTrue(BillingAddress(address = buildBillingAddress(addressLine2 = "addressLine2")).isEdited())
+
+    @Test
+    fun `If BillingAddress city is edited then edited() should return true`() =
+        assertTrue(BillingAddress(address = buildBillingAddress(city = "city")).isEdited())
+
+    @Test
+    fun `If BillingAddress state is edited then edited() should return true`() =
+        assertTrue(BillingAddress(address = buildBillingAddress(state = "state")).isEdited())
+
+    @Test
+    fun `If BillingAddress zip is edited then edited() should return true`() =
+        assertTrue(BillingAddress(address = buildBillingAddress(zip = "zip")).isEdited())
+
+    @Test
+    fun `If BillingAddress country is edited then edited() should return true`() =
+        assertTrue(BillingAddress(address = buildBillingAddress(country = Country.ANGOLA)).isEdited())
+
+    private companion object {
+        private fun buildBillingAddress(
+            addressLine1: String = "",
+            addressLine2: String = "",
+            city: String = "",
+            state: String = "",
+            zip: String = "",
+            country: Country = DEFAULT_BILLING_ADDRESS.address!!.country,
+        ) = Address(addressLine1, addressLine2, city, state, zip, country)
+    }
+}

--- a/frames/src/test/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModelTest.kt
@@ -160,7 +160,8 @@ internal class PaymentDetailsViewModelTest {
         initViewModel(style)
 
         // Then
-        verify { mockPaymentStateManager.resetPaymentState(isCvvValid, isBillingAddressValid) }
+        val isBillingAddressEnabled = !isAddressStyleNull
+        verify { mockPaymentStateManager.resetPaymentState(isCvvValid, isBillingAddressValid, isBillingAddressEnabled) }
     }
 
     private fun initViewModel(style: PaymentDetailsStyle) {


### PR DESCRIPTION
## Issue

[PIMOB-1767](https://checkout.atlassian.net/browse/PIMOB-1767)

## Proposed changes

**Problem**
Currently the `BillingAddress` is including the payment tokenisation process no matter whether the form is enabled or whether the `BillingAddress` is edited by the user. Which causes the SDK sending a default empty `BillingAddress` with the default country instead of a `null` value.

**Solution**
* Add a new field `PaymentStateManager#isBillingAddressEnabled: MutableStateFlow<Boolean>` to store a boolean of payment form is enabled.
* Add a new method `BillingAddress#isEdited()` to compare the current data is same as a default one.
* Use the field and method mentioned above in `PayButtonViewModel#provideCardData` to decide whether we need to provide the `BillingAddress` data. We should provide it only when the *billing address is enabled* and *the address is edited*.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x] Reviewers assigned
* [x] I have performed a self-review of my code and manual testing
* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have added necessary documentation (if applicable)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered, etc...


[PIMOB-1767]: https://checkout.atlassian.net/browse/PIMOB-1767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ