### PR TITLE
Feature/pimob 1767

### DIFF
--- a/frames/src/main/java/com/checkout/frames/component/country/CountryComponent.kt
+++ b/frames/src/main/java/com/checkout/frames/component/country/CountryComponent.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.checkout.base.model.Country
 import com.checkout.frames.component.base.InputComponent
 import com.checkout.frames.di.base.Injector
 import com.checkout.frames.style.component.CountryComponentStyle
@@ -13,13 +14,14 @@ import com.checkout.frames.style.component.CountryComponentStyle
 internal fun CountryComponent(
     style: CountryComponentStyle,
     injector: Injector,
-    goToCountryPicker: () -> Unit
+    onCountryUpdated: (country: Country) -> Unit,
+    goToCountryPicker: () -> Unit,
 ) {
     val viewModel: CountryViewModel = viewModel(
         factory = CountryViewModel.Factory(injector, style)
     )
 
-    viewModel.prepare()
+    viewModel.prepare(onCountryUpdated)
 
     with(viewModel.componentStyle.inputFieldStyle) {
         modifier = modifier.clickable(

--- a/frames/src/main/java/com/checkout/frames/component/country/CountryViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/component/country/CountryViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.checkout.base.mapper.Mapper
+import com.checkout.base.model.Country
+import com.checkout.frames.R
 import com.checkout.frames.component.base.InputComponentState
 import com.checkout.frames.di.base.InjectionClient
 import com.checkout.frames.di.base.Injector
@@ -28,7 +30,7 @@ internal class CountryViewModel @Inject constructor(
     val componentState = provideViewState(style.inputStyle)
     val componentStyle = provideViewStyle(style.inputStyle)
 
-    fun prepare() {
+    fun prepare(onCountryUpdated: (country: Country) -> Unit) {
         viewModelScope.launch {
             paymentStateManager.billingAddress.collect { billingAddress ->
                 val country = billingAddress.address?.country
@@ -38,6 +40,22 @@ internal class CountryViewModel @Inject constructor(
                 val emojiFlag = country?.emojiFlag()
 
                 componentState.inputFieldState.text.value = "$emojiFlag    $name"
+
+                onCountryUpdated(country ?: Country.INVALID_COUNTRY)
+                maybeShowErrorMessage(country)
+            }
+        }
+    }
+
+    private fun maybeShowErrorMessage(country: Country?) {
+        if (paymentStateManager.visitedCountryPicker.value) {
+            with(componentState.errorState) {
+                if (country == Country.INVALID_COUNTRY) {
+                    isVisible.value = true
+                    textId.value = R.string.cko_billing_form_input_field_phone_country_error
+                } else {
+                    isVisible.value = false
+                }
             }
         }
     }

--- a/frames/src/main/java/com/checkout/frames/component/paybutton/PayButtonViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/component/paybutton/PayButtonViewModel.kt
@@ -63,9 +63,7 @@ internal class PayButtonViewModel @Inject constructor(
         .apply { modifier = modifier.fillMaxWidth() }
 
     private fun provideCardData(): Card = with(paymentStateManager) {
-        /**
-         * Get the BillingAddress value only if "the billing address is enabled" and "the address is edited".
-         */
+        // Get the BillingAddress value only if "the billing address is enabled" and "the address is edited".
         val address = billingAddress.value.takeIf { isBillingAddressEnabled.value && it.isEdited() }
 
         Card(

--- a/frames/src/main/java/com/checkout/frames/component/paybutton/PayButtonViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/component/paybutton/PayButtonViewModel.kt
@@ -10,11 +10,12 @@ import com.checkout.frames.di.base.InjectionClient
 import com.checkout.frames.di.base.Injector
 import com.checkout.frames.di.component.PayButtonViewModelSubComponent
 import com.checkout.frames.logging.PaymentFormEventType
+import com.checkout.frames.model.request.InternalCardTokenRequest
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress.Companion.isEdited
 import com.checkout.frames.screen.manager.PaymentStateManager
 import com.checkout.frames.style.component.PayButtonComponentStyle
 import com.checkout.frames.style.component.base.ButtonStyle
 import com.checkout.frames.style.view.InternalButtonViewStyle
-import com.checkout.frames.model.request.InternalCardTokenRequest
 import com.checkout.frames.utils.extensions.logEvent
 import com.checkout.frames.utils.extensions.toExpiryDate
 import com.checkout.frames.view.InternalButtonState
@@ -30,7 +31,7 @@ internal class PayButtonViewModel @Inject constructor(
     private val paymentStateManager: PaymentStateManager,
     private val cardTokenizationUseCase: UseCase<InternalCardTokenRequest, Unit>,
     private val buttonStyleMapper: Mapper<ButtonStyle, InternalButtonViewStyle>,
-    private val buttonStateMapper: Mapper<ButtonStyle, InternalButtonState>,
+    buttonStateMapper: Mapper<ButtonStyle, InternalButtonState>,
     private val logger: Logger<LoggingEvent>
 ) : ViewModel() {
 
@@ -62,14 +63,18 @@ internal class PayButtonViewModel @Inject constructor(
         .apply { modifier = modifier.fillMaxWidth() }
 
     private fun provideCardData(): Card = with(paymentStateManager) {
-        val billingAddress = billingAddress.value
+        /**
+         * Get the BillingAddress value only if "the billing address is enabled" and "the address is edited".
+         */
+        val address = billingAddress.value.takeIf { isBillingAddressEnabled.value && it.isEdited() }
+
         Card(
             expiryDate.value.toExpiryDate(),
-            billingAddress.name,
+            address?.name,
             cardNumber.value,
             cvv.value,
-            billingAddress.address,
-            billingAddress.phone
+            address?.address,
+            address?.phone
         )
     }
 

--- a/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/BillingAddressDetailsScreen.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/BillingAddressDetailsScreen.kt
@@ -2,21 +2,22 @@ package com.checkout.frames.screen.billingaddress.billingaddressdetails
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
-import com.checkout.frames.di.base.Injector
 import com.checkout.frames.component.billingaddressfields.BillingAddressDynamicInputComponent
 import com.checkout.frames.component.country.CountryComponent
+import com.checkout.frames.di.base.Injector
 import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingFormFields
 import com.checkout.frames.screen.navigation.Screen
 import com.checkout.frames.style.screen.BillingAddressDetailsStyle
@@ -65,19 +66,19 @@ internal fun BillingAddressDetailsScreen(
                 .fillMaxWidth()
                 .fillMaxHeight()
         ) {
-            items(viewModel.inputComponentViewStyleList.size) { index ->
-                if (
-                    viewModel.inputComponentViewStyleList[index].addressFieldName
-                    == BillingFormFields.Country.name
-                ) {
-                    CountryComponent(style.countryComponentStyle, injector) {
-                        navController.navigate(Screen.CountryPicker.route)
-                    }
+            itemsIndexed(items = viewModel.inputComponentsStateList) { index, state ->
+                if (state.addressFieldName == BillingFormFields.Country.name) {
+                    CountryComponent(
+                        style = style.countryComponentStyle,
+                        injector = injector,
+                        onCountryUpdated = { country -> viewModel.updateCountryComponentState(state, country) },
+                        goToCountryPicker = { navController.navigate(Screen.CountryPicker.route) },
+                    )
                 } else {
                     BillingAddressDynamicInputComponent(
                         position = index,
                         inputComponentViewStyle = viewModel.inputComponentViewStyleList[index],
-                        inputComponentState = viewModel.inputComponentsStateList[index],
+                        inputComponentState = state,
                         onFocusChanged = viewModel::onFocusChanged,
                         onValueChange = viewModel::onAddressFieldTextChange
                     )

--- a/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
@@ -1,15 +1,14 @@
 package com.checkout.frames.screen.billingaddress.billingaddressdetails.models
 
 import com.checkout.base.model.Country
-import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress.Companion.DEFAULT_BILLING_ADDRESS
 import com.checkout.tokenization.model.Address
 import com.checkout.tokenization.model.Phone
-import java.util.*
+import java.util.Locale
 
 internal data class BillingAddress(
     val name: String? = null,
     val address: Address? = null,
-    var phone: Phone? = null,
+    var phone: Phone? = null
 ) {
     internal constructor() : this(
         "",

--- a/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
@@ -18,9 +18,7 @@ internal data class BillingAddress(
     internal companion object {
         internal val DEFAULT_BILLING_ADDRESS by lazy { BillingAddress() }
 
-        /**
-         * Whether the [BillingAddress] has been edited or same as the default one.
-         */
+        // Whether the [BillingAddress] has been edited or same as the default one.
         internal fun BillingAddress.isEdited() = (name == DEFAULT_BILLING_ADDRESS.name &&
                 address?.addressLine1 == DEFAULT_BILLING_ADDRESS.address?.addressLine1 &&
                 address?.addressLine2 == DEFAULT_BILLING_ADDRESS.address?.addressLine2 &&

--- a/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
@@ -3,7 +3,6 @@ package com.checkout.frames.screen.billingaddress.billingaddressdetails.models
 import com.checkout.base.model.Country
 import com.checkout.tokenization.model.Address
 import com.checkout.tokenization.model.Phone
-import java.util.Locale
 
 internal data class BillingAddress(
     val name: String? = null,
@@ -12,7 +11,7 @@ internal data class BillingAddress(
 ) {
     internal constructor() : this(
         "",
-        Address("", "", "", "", "", Country.from(Locale.getDefault().country))
+        Address("", "", "", "", "", Country.INVALID_COUNTRY)
     )
 
     internal companion object {

--- a/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
@@ -1,17 +1,34 @@
 package com.checkout.frames.screen.billingaddress.billingaddressdetails.models
 
 import com.checkout.base.model.Country
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress.Companion.DEFAULT_BILLING_ADDRESS
 import com.checkout.tokenization.model.Address
 import com.checkout.tokenization.model.Phone
-import java.util.Locale
+import java.util.*
 
 internal data class BillingAddress(
     val name: String? = null,
     val address: Address? = null,
-    var phone: Phone? = null
+    var phone: Phone? = null,
 ) {
     internal constructor() : this(
         "",
         Address("", "", "", "", "", Country.from(Locale.getDefault().country))
     )
+
+    internal companion object {
+        internal val DEFAULT_BILLING_ADDRESS by lazy { BillingAddress() }
+
+        /**
+         * Whether the [BillingAddress] has been edited or same as the default one.
+         */
+        internal fun BillingAddress.isEdited() = (name == DEFAULT_BILLING_ADDRESS.name &&
+                address?.addressLine1 == DEFAULT_BILLING_ADDRESS.address?.addressLine1 &&
+                address?.addressLine2 == DEFAULT_BILLING_ADDRESS.address?.addressLine2 &&
+                address?.city == DEFAULT_BILLING_ADDRESS.address?.city &&
+                address?.state == DEFAULT_BILLING_ADDRESS.address?.state &&
+                address?.zip == DEFAULT_BILLING_ADDRESS.address?.zip &&
+                address?.country == DEFAULT_BILLING_ADDRESS.address?.country &&
+                phone == DEFAULT_BILLING_ADDRESS.phone).not()
+    }
 }

--- a/frames/src/main/java/com/checkout/frames/screen/manager/PaymentFormStateManager.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/manager/PaymentFormStateManager.kt
@@ -26,6 +26,7 @@ internal class PaymentFormStateManager(
 
     override val billingAddress: MutableStateFlow<BillingAddress> = MutableStateFlow(BillingAddress())
     override val isBillingAddressValid: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    override val isBillingAddressEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     override val supportedCardSchemeList = provideCardSchemeList()
 
@@ -33,7 +34,8 @@ internal class PaymentFormStateManager(
 
     override fun resetPaymentState(
         isCvvValid: Boolean,
-        isBillingAddressValid: Boolean
+        isBillingAddressValid: Boolean,
+        isBillingAddressEnabled: Boolean,
     ) {
         cardNumber.value = ""
         cardScheme.value = CardScheme.UNKNOWN
@@ -44,6 +46,7 @@ internal class PaymentFormStateManager(
         this.isCvvValid.value = isCvvValid
         billingAddress.value = BillingAddress()
         this.isBillingAddressValid.value = isBillingAddressValid
+        this.isBillingAddressEnabled.value = isBillingAddressEnabled
     }
 
     @VisibleForTesting

--- a/frames/src/main/java/com/checkout/frames/screen/manager/PaymentFormStateManager.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/manager/PaymentFormStateManager.kt
@@ -27,6 +27,7 @@ internal class PaymentFormStateManager(
     override val billingAddress: MutableStateFlow<BillingAddress> = MutableStateFlow(BillingAddress())
     override val isBillingAddressValid: MutableStateFlow<Boolean> = MutableStateFlow(false)
     override val isBillingAddressEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    override val visitedCountryPicker: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     override val supportedCardSchemeList = provideCardSchemeList()
 
@@ -45,6 +46,7 @@ internal class PaymentFormStateManager(
         cvv.value = ""
         this.isCvvValid.value = isCvvValid
         billingAddress.value = BillingAddress()
+        visitedCountryPicker.value = false
         this.isBillingAddressValid.value = isBillingAddressValid
         this.isBillingAddressEnabled.value = isBillingAddressEnabled
     }

--- a/frames/src/main/java/com/checkout/frames/screen/manager/PaymentStateManager.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/manager/PaymentStateManager.kt
@@ -21,11 +21,14 @@ internal interface PaymentStateManager {
 
     val billingAddress: MutableStateFlow<BillingAddress>
     val isBillingAddressValid: MutableStateFlow<Boolean>
+    // Whether the billing address form is enabled or set to null
+    val isBillingAddressEnabled: MutableStateFlow<Boolean>
 
     val isReadyForTokenization: StateFlow<Boolean>
 
     fun resetPaymentState(
         isCvvValid: Boolean,
-        isBillingAddressValid: Boolean
+        isBillingAddressValid: Boolean,
+        isBillingAddressEnabled: Boolean,
     )
 }

--- a/frames/src/main/java/com/checkout/frames/screen/manager/PaymentStateManager.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/manager/PaymentStateManager.kt
@@ -24,6 +24,8 @@ internal interface PaymentStateManager {
     // Whether the billing address form is enabled or set to null
     val isBillingAddressEnabled: MutableStateFlow<Boolean>
 
+    val visitedCountryPicker: MutableStateFlow<Boolean>
+
     val isReadyForTokenization: StateFlow<Boolean>
 
     fun resetPaymentState(

--- a/frames/src/main/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModel.kt
@@ -35,11 +35,11 @@ internal class PaymentDetailsViewModel @Inject constructor(
     val componentProvider: ComponentProvider,
     private val textLabelStyleMapper: Mapper<TextLabelStyle, TextLabelViewStyle>,
     private val textLabelStateMapper: Mapper<TextLabelStyle?, TextLabelState>,
-    private val containerMapper: Mapper<ContainerStyle, Modifier>,
+    containerMapper: Mapper<ContainerStyle, Modifier>,
     private val clickableImageStyleMapper: ImageStyleToClickableComposableImageMapper,
     @Named(CLOSE_PAYMENT_FLOW_DI)
     private val closePaymentFlowUseCase: UseCase<Unit, Unit>,
-    private val paymentStateManager: PaymentStateManager,
+    paymentStateManager: PaymentStateManager,
     private val logger: Logger<LoggingEvent>,
     private val style: PaymentDetailsStyle
 ) : ViewModel() {
@@ -51,7 +51,12 @@ internal class PaymentDetailsViewModel @Inject constructor(
     init {
         val isCvvValidByDefault = style.cvvStyle == null
         val isBillingAddressValidByDefault = style.addressSummaryStyle?.isOptional ?: true
-        paymentStateManager.resetPaymentState(isCvvValidByDefault, isBillingAddressValidByDefault)
+        val isBillingAddressValidEnabled = style.addressSummaryStyle != null
+        paymentStateManager.resetPaymentState(
+            isCvvValidByDefault,
+            isBillingAddressValidByDefault,
+            isBillingAddressValidEnabled
+        )
         logger.logEventWithLocale(PaymentFormEventType.PRESENTED)
     }
 

--- a/frames/src/main/res/values-ar/strings.xml
+++ b/frames/src/main/res/values-ar/strings.xml
@@ -32,4 +32,5 @@
     <string name="cko_billing_form_input_field_address_line_two">سطر العنوان الثاني</string>
     <string name="cko_billing_form_input_field_state">المنطقة</string>
     <string name="cko_billing_form_input_field_postcode">الرمز البريدي</string>
+    <string name="cko_billing_form_input_field_phone_country_error">يُرجى إختيار الدولة</string>
 </resources>

--- a/frames/src/main/res/values-de/strings.xml
+++ b/frames/src/main/res/values-de/strings.xml
@@ -32,4 +32,5 @@
     <string name="cko_billing_form_input_field_address_line_two">Addresszeile 2</string>
     <string name="cko_billing_form_input_field_state">Bundesland</string>
     <string name="cko_billing_form_input_field_postcode">Postleitzahl</string>
+    <string name="cko_billing_form_input_field_phone_country_error">Fehlendes Land</string>
 </resources>

--- a/frames/src/main/res/values-es/strings.xml
+++ b/frames/src/main/res/values-es/strings.xml
@@ -32,4 +32,5 @@
     <string name="cko_billing_form_input_field_address_line_two">Dirección línea 2</string>
     <string name="cko_billing_form_input_field_state">Comunidad Autónoma</string>
     <string name="cko_billing_form_input_field_postcode">Código postal</string>
+    <string name="cko_billing_form_input_field_phone_country_error">Selecciona tu país</string>
 </resources>

--- a/frames/src/main/res/values-fr/strings.xml
+++ b/frames/src/main/res/values-fr/strings.xml
@@ -32,4 +32,5 @@
     <string name="cko_billing_form_input_field_address_line_two">Adresse ligne 2</string>
     <string name="cko_billing_form_input_field_state">Département</string>
     <string name="cko_billing_form_input_field_postcode">Code postal</string>
+    <string name="cko_billing_form_input_field_phone_country_error">Pays manquant</string>
 </resources>

--- a/frames/src/main/res/values-it/strings.xml
+++ b/frames/src/main/res/values-it/strings.xml
@@ -32,4 +32,5 @@
     <string name="cko_billing_form_input_field_address_line_two">Indirizzo linea 2</string>
     <string name="cko_billing_form_input_field_state">Regione</string>
     <string name="cko_billing_form_input_field_postcode">Codice postale</string>
+    <string name="cko_billing_form_input_field_phone_country_error">Paese scomparso</string>
 </resources>

--- a/frames/src/main/res/values-nl/strings.xml
+++ b/frames/src/main/res/values-nl/strings.xml
@@ -32,4 +32,5 @@
     <string name="cko_billing_form_input_field_address_line_two">Adres regel 2</string>
     <string name="cko_billing_form_input_field_state">Provincie</string>
     <string name="cko_billing_form_input_field_postcode">Postcode</string>
+    <string name="cko_billing_form_input_field_phone_country_error">" Ontbrekend land"</string>
 </resources>

--- a/frames/src/main/res/values-ro/strings.xml
+++ b/frames/src/main/res/values-ro/strings.xml
@@ -32,4 +32,5 @@
     <string name="cko_billing_form_input_field_address_line_two">Linia 2 de adresă</string>
     <string name="cko_billing_form_input_field_state">Județ</string>
     <string name="cko_billing_form_input_field_postcode">Codul poștal</string>
+    <string name="cko_billing_form_input_field_phone_country_error">Alegeți țara</string>
 </resources>

--- a/frames/src/main/res/values/strings.xml
+++ b/frames/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="cko_billing_form_input_field_state_error" translatable="true">Missing State</string>
     <string name="cko_billing_form_input_field_post_code_error" translatable="true">Missing Postcode</string>
     <string name="cko_billing_form_input_field_phone_number_error" translatable="true">Missing Phone number</string>
+    <string name="cko_billing_form_input_field_phone_country_error" translatable="true">Missing Country</string>
 
     <!--Billing address summary-->
     <string name="cko_billing_address" translatable="true">Billing address</string>

--- a/frames/src/test/java/com/checkout/frames/component/country/CountryViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/component/country/CountryViewModelTest.kt
@@ -5,13 +5,13 @@ import com.checkout.base.mapper.Mapper
 import com.checkout.base.model.Country
 import com.checkout.frames.component.base.InputComponentState
 import com.checkout.frames.mapper.ContainerStyleToModifierMapper
-import com.checkout.frames.mapper.TextLabelStyleToViewStyleMapper
 import com.checkout.frames.mapper.ImageStyleToComposableImageMapper
-import com.checkout.frames.mapper.InputComponentStyleToViewStyleMapper
-import com.checkout.frames.mapper.InputFieldStyleToViewStyleMapper
-import com.checkout.frames.mapper.InputFieldStyleToInputFieldStateMapper
 import com.checkout.frames.mapper.InputComponentStyleToStateMapper
+import com.checkout.frames.mapper.InputComponentStyleToViewStyleMapper
+import com.checkout.frames.mapper.InputFieldStyleToInputFieldStateMapper
+import com.checkout.frames.mapper.InputFieldStyleToViewStyleMapper
 import com.checkout.frames.mapper.TextLabelStyleToStateMapper
+import com.checkout.frames.mapper.TextLabelStyleToViewStyleMapper
 import com.checkout.frames.screen.manager.PaymentFormStateManager
 import com.checkout.frames.screen.manager.PaymentStateManager
 import com.checkout.frames.style.component.CountryComponentStyle
@@ -99,13 +99,28 @@ internal class CountryViewModelTest {
     /** Country field update **/
 
     @Test
+    fun `when country field data is updated it should call onCountryUpdated`() = runTest {
+        // Given
+        spyPaymentStateManager.billingAddress.value.address?.country = Country.UNITED_KINGDOM
+
+        fun assertUpdatedCountry(expectedCountry: Country, actualCountry: Country) {
+            assertEquals(expectedCountry, actualCountry)
+        }
+        // When
+        viewModel.prepare { actualCountry ->
+            // Then
+            assertUpdatedCountry(Country.UNITED_KINGDOM, actualCountry)
+        }
+    }
+
+    @Test
     fun `when country in payment state manager is changed then country field data is updated`() = runTest {
         // Given
         val testCountry = Country.UNITED_STATES_OF_AMERICA
         val expectedCountryFieldText = "\uD83C\uDDFA\uD83C\uDDF8    United States"
 
         spyPaymentStateManager.billingAddress.value.address?.country = Country.UNITED_KINGDOM
-        viewModel.prepare()
+        viewModel.prepare { }
 
         // When
         spyPaymentStateManager.billingAddress.value.address?.country = testCountry

--- a/frames/src/test/java/com/checkout/frames/countrypicker/CountryPickerViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/countrypicker/CountryPickerViewModelTest.kt
@@ -241,6 +241,14 @@ internal class CountryPickerViewModelTest {
         assertTrue(viewModel.searchFieldState.text.value.isEmpty())
     }
 
+    @Test
+    fun `onLeaveScreen should update visitedCountryPicker to true in PaymentStateManager`() {
+        paymentStateManager.visitedCountryPicker.value = false
+        assertFalse(paymentStateManager.visitedCountryPicker.value)
+        viewModel.onLeaveScreen()
+        assertTrue(paymentStateManager.visitedCountryPicker.value)
+    }
+
     private fun initMappers() {
         val imageMapper = ImageStyleToComposableImageMapper()
 

--- a/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
+++ b/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
@@ -40,7 +40,7 @@ internal class PaymentFormStateManagerTest {
     @ParameterizedTest(
         name = "When reset of payment state is requested with: " +
                 "isCvvValid = {0} and isBillingAddressValid = {1}; " +
-                "Then default cvv isValid state = {0} and address isValid state = {1}"
+                "Then default cvv isValid state = {0}, address isValid state = {1} and address isEnabled state = {2}"
     )
     @MethodSource("resetArguments")
     fun `when reset of payment state is requested then payment state is returned to a default state`(
@@ -84,10 +84,14 @@ internal class PaymentFormStateManagerTest {
         @RequiresApi(Build.VERSION_CODES.N)
         @JvmStatic
         fun resetArguments(): Stream<Arguments> = Stream.of(
-            Arguments.of(false, false),
-            Arguments.of(true, false),
-            Arguments.of(false, true),
-            Arguments.of(true, true)
+            Arguments.of(false, false, true),
+            Arguments.of(true, false, true),
+            Arguments.of(false, true, true),
+            Arguments.of(true, true, true),
+            Arguments.of(false, false, false),
+            Arguments.of(true, false, false),
+            Arguments.of(false, true, false),
+            Arguments.of(true, true, false),
         )
     }
 }

--- a/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
+++ b/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
@@ -45,7 +45,8 @@ internal class PaymentFormStateManagerTest {
     @MethodSource("resetArguments")
     fun `when reset of payment state is requested then payment state is returned to a default state`(
         isCvvValid: Boolean,
-        isBillingAddressValid: Boolean
+        isBillingAddressValid: Boolean,
+        isBillingAddressEnabled: Boolean,
     ) {
         // Given
         val supportedSchemes = listOf(CardScheme.VISA, CardScheme.DISCOVER)
@@ -61,9 +62,10 @@ internal class PaymentFormStateManagerTest {
             phone = Phone("+4332452452345234", Country.UNITED_KINGDOM)
         )
         paymentFormStateManager.isBillingAddressValid.value = !isBillingAddressValid
+        paymentFormStateManager.isBillingAddressEnabled.value = !isBillingAddressEnabled
 
         // When
-        paymentFormStateManager.resetPaymentState(isCvvValid, isBillingAddressValid)
+        paymentFormStateManager.resetPaymentState(isCvvValid, isBillingAddressValid, isBillingAddressEnabled)
 
         // Then
         Assertions.assertEquals(paymentFormStateManager.cvv.value, "")
@@ -74,6 +76,7 @@ internal class PaymentFormStateManagerTest {
         Assertions.assertEquals(paymentFormStateManager.isExpiryDateValid.value, false)
         Assertions.assertEquals(paymentFormStateManager.billingAddress.value, BillingAddress())
         Assertions.assertEquals(paymentFormStateManager.isBillingAddressValid.value, isBillingAddressValid)
+        Assertions.assertEquals(paymentFormStateManager.isBillingAddressEnabled.value, isBillingAddressEnabled)
         Assertions.assertEquals(paymentFormStateManager.supportedCardSchemeList, supportedSchemes)
     }
 

--- a/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
+++ b/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
@@ -63,6 +63,7 @@ internal class PaymentFormStateManagerTest {
         )
         paymentFormStateManager.isBillingAddressValid.value = !isBillingAddressValid
         paymentFormStateManager.isBillingAddressEnabled.value = !isBillingAddressEnabled
+        paymentFormStateManager.visitedCountryPicker.value = true
 
         // When
         paymentFormStateManager.resetPaymentState(isCvvValid, isBillingAddressValid, isBillingAddressEnabled)
@@ -77,6 +78,7 @@ internal class PaymentFormStateManagerTest {
         Assertions.assertEquals(paymentFormStateManager.billingAddress.value, BillingAddress())
         Assertions.assertEquals(paymentFormStateManager.isBillingAddressValid.value, isBillingAddressValid)
         Assertions.assertEquals(paymentFormStateManager.isBillingAddressEnabled.value, isBillingAddressEnabled)
+        Assertions.assertEquals(paymentFormStateManager.visitedCountryPicker.value, false)
         Assertions.assertEquals(paymentFormStateManager.supportedCardSchemeList, supportedSchemes)
     }
 

--- a/frames/src/test/java/com/checkout/frames/screen/billingaddressdetails/models/BillingAddressTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/billingaddressdetails/models/BillingAddressTest.kt
@@ -1,0 +1,60 @@
+package com.checkout.frames.screen.billingaddressdetails.models
+
+import com.checkout.base.model.Country
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress.Companion.DEFAULT_BILLING_ADDRESS
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress.Companion.isEdited
+import com.checkout.tokenization.model.Address
+import com.checkout.tokenization.model.Phone
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+
+internal class BillingAddressTest {
+    @Test
+    fun `A default BillingAddress should not be edited`() = assertFalse(BillingAddress().isEdited())
+
+    @Test
+    fun `If BillingAddress name is edited then edited() should return true`() =
+        assertTrue(BillingAddress(name = "NAME").isEdited())
+
+    @Test
+    fun `If BillingAddress phone is edited then edited() should return true`() =
+        assertTrue(BillingAddress(phone = Phone(number = "1234", Country.AFGHANISTAN)).isEdited())
+
+    @Test
+    fun `If BillingAddress addressLine1 is edited then edited() should return true`() =
+        assertTrue(BillingAddress(address = buildBillingAddress(addressLine1 = "addressLine1")).isEdited())
+
+    @Test
+    fun `If BillingAddress addressLine2 is edited then edited() should return true`() =
+        assertTrue(BillingAddress(address = buildBillingAddress(addressLine2 = "addressLine2")).isEdited())
+
+    @Test
+    fun `If BillingAddress city is edited then edited() should return true`() =
+        assertTrue(BillingAddress(address = buildBillingAddress(city = "city")).isEdited())
+
+    @Test
+    fun `If BillingAddress state is edited then edited() should return true`() =
+        assertTrue(BillingAddress(address = buildBillingAddress(state = "state")).isEdited())
+
+    @Test
+    fun `If BillingAddress zip is edited then edited() should return true`() =
+        assertTrue(BillingAddress(address = buildBillingAddress(zip = "zip")).isEdited())
+
+    @Test
+    fun `If BillingAddress country is edited then edited() should return true`() =
+        assertTrue(BillingAddress(address = buildBillingAddress(country = Country.ANGOLA)).isEdited())
+
+    private companion object {
+        private fun buildBillingAddress(
+            addressLine1: String = "",
+            addressLine2: String = "",
+            city: String = "",
+            state: String = "",
+            zip: String = "",
+            country: Country = DEFAULT_BILLING_ADDRESS.address!!.country,
+        ) = Address(addressLine1, addressLine2, city, state, zip, country)
+    }
+}

--- a/frames/src/test/java/com/checkout/frames/screen/billingaddressdetails/models/BillingAddressTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/billingaddressdetails/models/BillingAddressTest.kt
@@ -6,6 +6,7 @@ import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.Bi
 import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress.Companion.isEdited
 import com.checkout.tokenization.model.Address
 import com.checkout.tokenization.model.Phone
+import org.amshove.kluent.internal.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -46,6 +47,11 @@ internal class BillingAddressTest {
     @Test
     fun `If BillingAddress country is edited then edited() should return true`() =
         assertTrue(BillingAddress(address = buildBillingAddress(country = Country.ANGOLA)).isEdited())
+
+    @Test
+    fun `Default BillingAddress country is INVALID_COUNTRY`() {
+        assertEquals(Country.INVALID_COUNTRY, BillingAddress().address!!.country)
+    }
 
     private companion object {
         private fun buildBillingAddress(

--- a/frames/src/test/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModelTest.kt
@@ -160,7 +160,8 @@ internal class PaymentDetailsViewModelTest {
         initViewModel(style)
 
         // Then
-        verify { mockPaymentStateManager.resetPaymentState(isCvvValid, isBillingAddressValid) }
+        val isBillingAddressEnabled = !isAddressStyleNull
+        verify { mockPaymentStateManager.resetPaymentState(isCvvValid, isBillingAddressValid, isBillingAddressEnabled) }
     }
 
     private fun initViewModel(style: PaymentDetailsStyle) {


### PR DESCRIPTION
## Issue

[PIMOB-1767](https://checkout.atlassian.net/browse/PIMOB-1767) **AC2**

* `BillingAddressDetailsScreen` is default to make the country valid without checking what country is selected. ie, when the country is `INVALID_COUNTRY`, the `Done` button will be enabled if the other required fields are filled. 
* `BillingAddress` default the country by calling `Locale.getdefault().country` which might produce a empty string and thus get the `INVALID_COUNTRY`

## Proposed changes

* Default the country in `BillingAddress` constructor to `INVALID_COUNTRY`.
* Make the country `BillingAddressInputComponentState` to be invalid if the country is `INVALID_COUNTRY`.
* Add a new flag `visitedCountryPicker: MutableStateFlow<Boolean>` in `PaymentStateManager` to track whether the user has visited the `CountryPickerScreen`. If so and no valid country is chosen then it should display the error message.

## Checklist

* [x] Reviewers assigned
* [x] I have performed a self-review of my code and manual testing
* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

* Not really sure adding the new flag `visitedCountryPicker: MutableStateFlow<Boolean>` in `PaymentStateManager` is the best solution but a working one. The main purpose is to have a shared flag between `CountryPickerViewModel` and `CountryViewModel`, and determine whether we should show the error message after the picker is visited and non valid country is selected.
