### PR TITLE
[Frame] Default country to empty and add ability to show error message 

### DIFF
--- a/frames/src/main/java/com/checkout/frames/component/country/CountryComponent.kt
+++ b/frames/src/main/java/com/checkout/frames/component/country/CountryComponent.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.checkout.base.model.Country
 import com.checkout.frames.component.base.InputComponent
 import com.checkout.frames.di.base.Injector
 import com.checkout.frames.style.component.CountryComponentStyle
@@ -13,13 +14,14 @@ import com.checkout.frames.style.component.CountryComponentStyle
 internal fun CountryComponent(
     style: CountryComponentStyle,
     injector: Injector,
-    goToCountryPicker: () -> Unit
+    onCountryUpdated: (country: Country) -> Unit,
+    goToCountryPicker: () -> Unit,
 ) {
     val viewModel: CountryViewModel = viewModel(
         factory = CountryViewModel.Factory(injector, style)
     )
 
-    viewModel.prepare()
+    viewModel.prepare(onCountryUpdated)
 
     with(viewModel.componentStyle.inputFieldStyle) {
         modifier = modifier.clickable(

--- a/frames/src/main/java/com/checkout/frames/component/country/CountryViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/component/country/CountryViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.checkout.base.mapper.Mapper
+import com.checkout.base.model.Country
+import com.checkout.frames.R
 import com.checkout.frames.component.base.InputComponentState
 import com.checkout.frames.di.base.InjectionClient
 import com.checkout.frames.di.base.Injector
@@ -28,7 +30,7 @@ internal class CountryViewModel @Inject constructor(
     val componentState = provideViewState(style.inputStyle)
     val componentStyle = provideViewStyle(style.inputStyle)
 
-    fun prepare() {
+    fun prepare(onCountryUpdated: (country: Country) -> Unit) {
         viewModelScope.launch {
             paymentStateManager.billingAddress.collect { billingAddress ->
                 val country = billingAddress.address?.country
@@ -38,6 +40,22 @@ internal class CountryViewModel @Inject constructor(
                 val emojiFlag = country?.emojiFlag()
 
                 componentState.inputFieldState.text.value = "$emojiFlag    $name"
+
+                onCountryUpdated(country ?: Country.INVALID_COUNTRY)
+                maybeShowErrorMessage(country)
+            }
+        }
+    }
+
+    private fun maybeShowErrorMessage(country: Country?) {
+        if (paymentStateManager.visitedCountryPicker.value) {
+            with(componentState.errorState) {
+                if (country == Country.INVALID_COUNTRY) {
+                    isVisible.value = true
+                    textId.value = R.string.cko_billing_form_input_field_phone_country_error
+                } else {
+                    isVisible.value = false
+                }
             }
         }
     }

--- a/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/BillingAddressDetailsScreen.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/BillingAddressDetailsScreen.kt
@@ -2,21 +2,22 @@ package com.checkout.frames.screen.billingaddress.billingaddressdetails
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
-import com.checkout.frames.di.base.Injector
 import com.checkout.frames.component.billingaddressfields.BillingAddressDynamicInputComponent
 import com.checkout.frames.component.country.CountryComponent
+import com.checkout.frames.di.base.Injector
 import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingFormFields
 import com.checkout.frames.screen.navigation.Screen
 import com.checkout.frames.style.screen.BillingAddressDetailsStyle
@@ -65,19 +66,19 @@ internal fun BillingAddressDetailsScreen(
                 .fillMaxWidth()
                 .fillMaxHeight()
         ) {
-            items(viewModel.inputComponentViewStyleList.size) { index ->
-                if (
-                    viewModel.inputComponentViewStyleList[index].addressFieldName
-                    == BillingFormFields.Country.name
-                ) {
-                    CountryComponent(style.countryComponentStyle, injector) {
-                        navController.navigate(Screen.CountryPicker.route)
-                    }
+            itemsIndexed(items = viewModel.inputComponentsStateList) { index, state ->
+                if (state.addressFieldName == BillingFormFields.Country.name) {
+                    CountryComponent(
+                        style = style.countryComponentStyle,
+                        injector = injector,
+                        onCountryUpdated = { country -> viewModel.updateCountryComponentState(state, country) },
+                        goToCountryPicker = { navController.navigate(Screen.CountryPicker.route) },
+                    )
                 } else {
                     BillingAddressDynamicInputComponent(
                         position = index,
                         inputComponentViewStyle = viewModel.inputComponentViewStyleList[index],
-                        inputComponentState = viewModel.inputComponentsStateList[index],
+                        inputComponentState = state,
                         onFocusChanged = viewModel::onFocusChanged,
                         onValueChange = viewModel::onAddressFieldTextChange
                     )

--- a/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
@@ -3,7 +3,6 @@ package com.checkout.frames.screen.billingaddress.billingaddressdetails.models
 import com.checkout.base.model.Country
 import com.checkout.tokenization.model.Address
 import com.checkout.tokenization.model.Phone
-import java.util.Locale
 
 internal data class BillingAddress(
     val name: String? = null,
@@ -12,7 +11,7 @@ internal data class BillingAddress(
 ) {
     internal constructor() : this(
         "",
-        Address("", "", "", "", "", Country.from(Locale.getDefault().country))
+        Address("", "", "", "", "", Country.INVALID_COUNTRY)
     )
 
     internal companion object {

--- a/frames/src/main/java/com/checkout/frames/screen/manager/PaymentFormStateManager.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/manager/PaymentFormStateManager.kt
@@ -27,6 +27,7 @@ internal class PaymentFormStateManager(
     override val billingAddress: MutableStateFlow<BillingAddress> = MutableStateFlow(BillingAddress())
     override val isBillingAddressValid: MutableStateFlow<Boolean> = MutableStateFlow(false)
     override val isBillingAddressEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    override val visitedCountryPicker: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     override val supportedCardSchemeList = provideCardSchemeList()
 
@@ -45,6 +46,7 @@ internal class PaymentFormStateManager(
         cvv.value = ""
         this.isCvvValid.value = isCvvValid
         billingAddress.value = BillingAddress()
+        visitedCountryPicker.value = false
         this.isBillingAddressValid.value = isBillingAddressValid
         this.isBillingAddressEnabled.value = isBillingAddressEnabled
     }

--- a/frames/src/main/java/com/checkout/frames/screen/manager/PaymentStateManager.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/manager/PaymentStateManager.kt
@@ -24,6 +24,8 @@ internal interface PaymentStateManager {
     // Whether the billing address form is enabled or set to null
     val isBillingAddressEnabled: MutableStateFlow<Boolean>
 
+    val visitedCountryPicker: MutableStateFlow<Boolean>
+
     val isReadyForTokenization: StateFlow<Boolean>
 
     fun resetPaymentState(

--- a/frames/src/main/res/values-ar/strings.xml
+++ b/frames/src/main/res/values-ar/strings.xml
@@ -32,4 +32,5 @@
     <string name="cko_billing_form_input_field_address_line_two">سطر العنوان الثاني</string>
     <string name="cko_billing_form_input_field_state">المنطقة</string>
     <string name="cko_billing_form_input_field_postcode">الرمز البريدي</string>
+    <string name="cko_billing_form_input_field_phone_country_error">يُرجى إختيار الدولة</string>
 </resources>

--- a/frames/src/main/res/values-de/strings.xml
+++ b/frames/src/main/res/values-de/strings.xml
@@ -32,4 +32,5 @@
     <string name="cko_billing_form_input_field_address_line_two">Addresszeile 2</string>
     <string name="cko_billing_form_input_field_state">Bundesland</string>
     <string name="cko_billing_form_input_field_postcode">Postleitzahl</string>
+    <string name="cko_billing_form_input_field_phone_country_error">Fehlendes Land</string>
 </resources>

--- a/frames/src/main/res/values-es/strings.xml
+++ b/frames/src/main/res/values-es/strings.xml
@@ -32,4 +32,5 @@
     <string name="cko_billing_form_input_field_address_line_two">Dirección línea 2</string>
     <string name="cko_billing_form_input_field_state">Comunidad Autónoma</string>
     <string name="cko_billing_form_input_field_postcode">Código postal</string>
+    <string name="cko_billing_form_input_field_phone_country_error">Selecciona tu país</string>
 </resources>

--- a/frames/src/main/res/values-fr/strings.xml
+++ b/frames/src/main/res/values-fr/strings.xml
@@ -32,4 +32,5 @@
     <string name="cko_billing_form_input_field_address_line_two">Adresse ligne 2</string>
     <string name="cko_billing_form_input_field_state">Département</string>
     <string name="cko_billing_form_input_field_postcode">Code postal</string>
+    <string name="cko_billing_form_input_field_phone_country_error">Pays manquant</string>
 </resources>

--- a/frames/src/main/res/values-it/strings.xml
+++ b/frames/src/main/res/values-it/strings.xml
@@ -32,4 +32,5 @@
     <string name="cko_billing_form_input_field_address_line_two">Indirizzo linea 2</string>
     <string name="cko_billing_form_input_field_state">Regione</string>
     <string name="cko_billing_form_input_field_postcode">Codice postale</string>
+    <string name="cko_billing_form_input_field_phone_country_error">Paese scomparso</string>
 </resources>

--- a/frames/src/main/res/values-nl/strings.xml
+++ b/frames/src/main/res/values-nl/strings.xml
@@ -32,4 +32,5 @@
     <string name="cko_billing_form_input_field_address_line_two">Adres regel 2</string>
     <string name="cko_billing_form_input_field_state">Provincie</string>
     <string name="cko_billing_form_input_field_postcode">Postcode</string>
+    <string name="cko_billing_form_input_field_phone_country_error">" Ontbrekend land"</string>
 </resources>

--- a/frames/src/main/res/values-ro/strings.xml
+++ b/frames/src/main/res/values-ro/strings.xml
@@ -32,4 +32,5 @@
     <string name="cko_billing_form_input_field_address_line_two">Linia 2 de adresă</string>
     <string name="cko_billing_form_input_field_state">Județ</string>
     <string name="cko_billing_form_input_field_postcode">Codul poștal</string>
+    <string name="cko_billing_form_input_field_phone_country_error">Alegeți țara</string>
 </resources>

--- a/frames/src/main/res/values/strings.xml
+++ b/frames/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="cko_billing_form_input_field_state_error" translatable="true">Missing State</string>
     <string name="cko_billing_form_input_field_post_code_error" translatable="true">Missing Postcode</string>
     <string name="cko_billing_form_input_field_phone_number_error" translatable="true">Missing Phone number</string>
+    <string name="cko_billing_form_input_field_phone_country_error" translatable="true">Missing Country</string>
 
     <!--Billing address summary-->
     <string name="cko_billing_address" translatable="true">Billing address</string>

--- a/frames/src/test/java/com/checkout/frames/component/country/CountryViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/component/country/CountryViewModelTest.kt
@@ -5,13 +5,13 @@ import com.checkout.base.mapper.Mapper
 import com.checkout.base.model.Country
 import com.checkout.frames.component.base.InputComponentState
 import com.checkout.frames.mapper.ContainerStyleToModifierMapper
-import com.checkout.frames.mapper.TextLabelStyleToViewStyleMapper
 import com.checkout.frames.mapper.ImageStyleToComposableImageMapper
-import com.checkout.frames.mapper.InputComponentStyleToViewStyleMapper
-import com.checkout.frames.mapper.InputFieldStyleToViewStyleMapper
-import com.checkout.frames.mapper.InputFieldStyleToInputFieldStateMapper
 import com.checkout.frames.mapper.InputComponentStyleToStateMapper
+import com.checkout.frames.mapper.InputComponentStyleToViewStyleMapper
+import com.checkout.frames.mapper.InputFieldStyleToInputFieldStateMapper
+import com.checkout.frames.mapper.InputFieldStyleToViewStyleMapper
 import com.checkout.frames.mapper.TextLabelStyleToStateMapper
+import com.checkout.frames.mapper.TextLabelStyleToViewStyleMapper
 import com.checkout.frames.screen.manager.PaymentFormStateManager
 import com.checkout.frames.screen.manager.PaymentStateManager
 import com.checkout.frames.style.component.CountryComponentStyle
@@ -99,13 +99,28 @@ internal class CountryViewModelTest {
     /** Country field update **/
 
     @Test
+    fun `when country field data is updated it should call onCountryUpdated`() = runTest {
+        // Given
+        spyPaymentStateManager.billingAddress.value.address?.country = Country.UNITED_KINGDOM
+
+        fun assertUpdatedCountry(expectedCountry: Country, actualCountry: Country) {
+            assertEquals(expectedCountry, actualCountry)
+        }
+        // When
+        viewModel.prepare { actualCountry ->
+            // Then
+            assertUpdatedCountry(Country.UNITED_KINGDOM, actualCountry)
+        }
+    }
+
+    @Test
     fun `when country in payment state manager is changed then country field data is updated`() = runTest {
         // Given
         val testCountry = Country.UNITED_STATES_OF_AMERICA
         val expectedCountryFieldText = "\uD83C\uDDFA\uD83C\uDDF8    United States"
 
         spyPaymentStateManager.billingAddress.value.address?.country = Country.UNITED_KINGDOM
-        viewModel.prepare()
+        viewModel.prepare { }
 
         // When
         spyPaymentStateManager.billingAddress.value.address?.country = testCountry

--- a/frames/src/test/java/com/checkout/frames/countrypicker/CountryPickerViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/countrypicker/CountryPickerViewModelTest.kt
@@ -241,6 +241,14 @@ internal class CountryPickerViewModelTest {
         assertTrue(viewModel.searchFieldState.text.value.isEmpty())
     }
 
+    @Test
+    fun `onLeaveScreen should update visitedCountryPicker to true in PaymentStateManager`() {
+        paymentStateManager.visitedCountryPicker.value = false
+        assertFalse(paymentStateManager.visitedCountryPicker.value)
+        viewModel.onLeaveScreen()
+        assertTrue(paymentStateManager.visitedCountryPicker.value)
+    }
+
     private fun initMappers() {
         val imageMapper = ImageStyleToComposableImageMapper()
 

--- a/frames/src/test/java/com/checkout/frames/countrypicker/CountryPickerViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/countrypicker/CountryPickerViewModelTest.kt
@@ -126,7 +126,10 @@ internal class CountryPickerViewModelTest {
     @Test
     fun `when view model is initialised then country picker shows all countries`() {
         // Then
-        assertEquals(Country.values().size, viewModel.searchCountries.value.size)
+        assertEquals(
+            Country.values().filter { it != Country.INVALID_COUNTRY }.size,
+            viewModel.searchCountries.value.size
+        )
     }
 
     @Test

--- a/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
+++ b/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
@@ -63,6 +63,7 @@ internal class PaymentFormStateManagerTest {
         )
         paymentFormStateManager.isBillingAddressValid.value = !isBillingAddressValid
         paymentFormStateManager.isBillingAddressEnabled.value = !isBillingAddressEnabled
+        paymentFormStateManager.visitedCountryPicker.value = true
 
         // When
         paymentFormStateManager.resetPaymentState(isCvvValid, isBillingAddressValid, isBillingAddressEnabled)
@@ -77,6 +78,7 @@ internal class PaymentFormStateManagerTest {
         Assertions.assertEquals(paymentFormStateManager.billingAddress.value, BillingAddress())
         Assertions.assertEquals(paymentFormStateManager.isBillingAddressValid.value, isBillingAddressValid)
         Assertions.assertEquals(paymentFormStateManager.isBillingAddressEnabled.value, isBillingAddressEnabled)
+        Assertions.assertEquals(paymentFormStateManager.visitedCountryPicker.value, false)
         Assertions.assertEquals(paymentFormStateManager.supportedCardSchemeList, supportedSchemes)
     }
 

--- a/frames/src/test/java/com/checkout/frames/screen/billingaddressdetails/models/BillingAddressTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/billingaddressdetails/models/BillingAddressTest.kt
@@ -6,6 +6,7 @@ import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.Bi
 import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress.Companion.isEdited
 import com.checkout.tokenization.model.Address
 import com.checkout.tokenization.model.Phone
+import org.amshove.kluent.internal.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -46,6 +47,11 @@ internal class BillingAddressTest {
     @Test
     fun `If BillingAddress country is edited then edited() should return true`() =
         assertTrue(BillingAddress(address = buildBillingAddress(country = Country.ANGOLA)).isEdited())
+
+    @Test
+    fun `Default BillingAddress country is INVALID_COUNTRY`() {
+        assertEquals(Country.INVALID_COUNTRY, BillingAddress().address!!.country)
+    }
 
     private companion object {
         private fun buildBillingAddress(


### PR DESCRIPTION
## Issue

[PIMOB-1767](https://checkout.atlassian.net/browse/PIMOB-1767) **AC2**

* `BillingAddressDetailsScreen` is default to make the country valid without checking what country is selected. ie, when the country is `INVALID_COUNTRY`, the `Done` button will be enabled if the other required fields are filled. 
* `BillingAddress` default the country by calling `Locale.getdefault().country` which might produce a empty string and thus get the `INVALID_COUNTRY`

## Proposed changes

* Default the country in `BillingAddress` constructor to `INVALID_COUNTRY`.
* Make the country `BillingAddressInputComponentState` to be invalid if the country is `INVALID_COUNTRY`.
* Add a new flag `visitedCountryPicker: MutableStateFlow<Boolean>` in `PaymentStateManager` to track whether the user has visited the `CountryPickerScreen`. If so and no valid country is chosen then it should display the error message.
* Disable auto making `BillingAddressInputComponentState` of country to be valid, it will be update whenever country has been chosen and only valid if a valid country is chosen.

## Checklist

* [x] Reviewers assigned
* [x] I have performed a self-review of my code and manual testing
* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

* Not really sure adding the new flag `visitedCountryPicker: MutableStateFlow<Boolean>` in `PaymentStateManager` is the best solution but a working one. The main purpose is to have a shared flag between `CountryPickerViewModel` and `CountryViewModel`, and determine whether we should show the error message after the picker is visited and non valid country is selected.


[PIMOB-1767]: https://checkout.atlassian.net/browse/PIMOB-1767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ