### PR TITLE
PIMOB-2040: Fixed expiry date crash

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -81,6 +81,7 @@ object Dependencies {
     const val kluent = "org.amshove.kluent:kluent:${Versions.kluent}"
     const val kluentAndroid = "org.amshove.kluent:kluent-android:${Versions.kluent}"
     const val robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
+    const val truth = "com.google.truth:truth:${Versions.truth}"
     const val okhttpMockServer = "com.squareup.okhttp3:mockwebserver:${Versions.okhttp}"
     const val kotlinCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.kotlinCoroutines}"
     const val jsonTest = "org.json:json:${Versions.jsonTest}"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -42,6 +42,7 @@ object Versions {
     const val kluent = "1.68"
     const val mockk = "1.11.0"
     const val robolectric = "4.8"
+    const val truth = "1.1.5"
 
     // Instrumented Testing Dependencies
     const val androidxJunit = "1.1.2"

--- a/buildSrc/src/main/java/com/checkout/buildsrc/AndroidJunit4Config.kt
+++ b/buildSrc/src/main/java/com/checkout/buildsrc/AndroidJunit4Config.kt
@@ -9,5 +9,6 @@ fun Project.applyAndroidJUnit4Configuration() {
         testImplementation(Dependencies.junit4)
         testImplementation(Dependencies.junitVintageEngine)
         testImplementation(Dependencies.robolectric)
+        testImplementation(Dependencies.truth)
     }
 }

--- a/frames/src/main/java/com/checkout/frames/component/expirydate/ExpiryDateVisualTransformation.kt
+++ b/frames/src/main/java/com/checkout/frames/component/expirydate/ExpiryDateVisualTransformation.kt
@@ -14,8 +14,7 @@ internal class ExpiryDateVisualTransformation : VisualTransformation {
     override fun filter(text: AnnotatedString) = performExpiryDateFilter(text)
 
     private fun performExpiryDateFilter(text: AnnotatedString): TransformedText {
-        // format: XX/XX
-        /*
+        /* format: MM/YY
          * Depending on the first number is where the separator will be placed
          * If the first number is 2-9 then the slash will come after the
          * 2, if the first number is 11 or 12 it will be after the second digit,

--- a/frames/src/main/java/com/checkout/frames/component/expirydate/ExpiryDateVisualTransformation.kt
+++ b/frames/src/main/java/com/checkout/frames/component/expirydate/ExpiryDateVisualTransformation.kt
@@ -15,46 +15,64 @@ internal class ExpiryDateVisualTransformation : VisualTransformation {
 
     private fun performExpiryDateFilter(text: AnnotatedString): TransformedText {
         // format: XX/XX
+        /*
+         * Depending on the first number is where the separator will be placed
+         * If the first number is 2-9 then the slash will come after the
+         * 2, if the first number is 11 or 12 it will be after the second digit,
+         * if the number is 01 it will be after the second digit.
+         */
+        val isSingleDigitMonth = text.isNotBlank() && !(text[0] == '0' || text[0] == '1')
 
-        val stringBuilder = StringBuilder()
-        for (i in text.indices) {
-            when {
-                i == 0 && text[i] > EXPIRY_DATE_ZERO_POSITION_CHECK -> {
-                    stringBuilder.append(EXPIRY_DATE_PREFIX_ZERO + text[i] + separator)
+        val output = buildString {
+            for ((index, char) in text.withIndex()) {
+                if (isSingleDigitMonth && index == 0 && char > EXPIRY_DATE_ZERO_POSITION_CHECK) {
+                    append(EXPIRY_DATE_PREFIX_ZERO + char + separator)
+                } else {
+                    append(char)
                 }
-                i == 1 && !stringBuilder.contains(separator) -> {
-                    stringBuilder.append(text[i] + separator)
-                }
-                else -> {
-                    stringBuilder.append(text[i])
+
+                if (index == 1 && !this.contains(separator)) {
+                    append(separator)
                 }
             }
         }
 
-        val expiryDateOffsetTranslator = object : OffsetMapping {
-            override fun originalToTransformed(offset: Int): Int {
-                val withZero = text.isNotEmpty() && text[0] > EXPIRY_DATE_ZERO_POSITION_CHECK
-                val zeroPrefix = if (withZero) 1 else 0
+        val outputOffsets = calculateOutputOffsets(output)
+        val separatorIndices = calculateSeparatorOffsets(output)
 
-                return when {
-                    offset == 0 -> offset
-                    !withZero && offset < 2 -> offset
-                    else -> offset + separator.length + zeroPrefix
-                }
+        val offsetTranslator = object : OffsetMapping {
+
+            override fun originalToTransformed(offset: Int): Int {
+                val updatedOffset: Int = if (isSingleDigitMonth) offset + 1 else offset
+
+                return outputOffsets[updatedOffset]
             }
 
             override fun transformedToOriginal(offset: Int): Int {
-                val withZero = text.isNotEmpty() && text[0] > EXPIRY_DATE_ZERO_POSITION_CHECK
-                val zeroPrefix = if (withZero) 1 else 0
+                val updatedOffset: Int = if (isSingleDigitMonth && offset > 0) offset - 1 else offset
+                val separatorCharactersBeforeOffset = separatorIndices.count { it < offset }
 
-                return when {
-                    offset == 0 -> offset
-                    !withZero && offset < 2 -> offset
-                    else -> offset - separator.length - zeroPrefix
-                }
+                return updatedOffset - separatorCharactersBeforeOffset
             }
         }
 
-        return TransformedText(AnnotatedString(stringBuilder.toString()), expiryDateOffsetTranslator)
+        return TransformedText(AnnotatedString(output), offsetTranslator)
+    }
+
+    private fun calculateOutputOffsets(output: String): List<Int> {
+        val digitOffsets = output.mapIndexedNotNull { index, char ->
+            // +1 because we're looking for offsets, not indices
+            index.takeIf { char.isDigit() }?.plus(1)
+        }
+        // We're adding 0 so that the cursor can be placed at the start of the text,
+        // and replace the last digit offset with the length of the output. The latter
+        // is so that the offsets are set correctly for text such as "04 / ".
+        return listOf(0) + digitOffsets.dropLast(1) + output.length
+    }
+
+    private fun calculateSeparatorOffsets(output: String): List<Int> {
+        return output.mapIndexedNotNull { index, c ->
+            index.takeUnless { c.isDigit() }
+        }
     }
 }

--- a/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/models/BillingAddress.kt
@@ -18,13 +18,15 @@ internal data class BillingAddress(
         internal val DEFAULT_BILLING_ADDRESS by lazy { BillingAddress() }
 
         // Whether the [BillingAddress] has been edited or same as the default one.
-        internal fun BillingAddress.isEdited() = (name == DEFAULT_BILLING_ADDRESS.name &&
+        internal fun BillingAddress.isEdited() = (
+                name == DEFAULT_BILLING_ADDRESS.name &&
                 address?.addressLine1 == DEFAULT_BILLING_ADDRESS.address?.addressLine1 &&
                 address?.addressLine2 == DEFAULT_BILLING_ADDRESS.address?.addressLine2 &&
                 address?.city == DEFAULT_BILLING_ADDRESS.address?.city &&
                 address?.state == DEFAULT_BILLING_ADDRESS.address?.state &&
                 address?.zip == DEFAULT_BILLING_ADDRESS.address?.zip &&
                 address?.country == DEFAULT_BILLING_ADDRESS.address?.country &&
-                phone == DEFAULT_BILLING_ADDRESS.phone).not()
+                phone == DEFAULT_BILLING_ADDRESS.phone
+                ).not()
     }
 }

--- a/frames/src/test/java/com/checkout/frames/component/expirydate/ExpiryDateVisualTransformationTest.kt
+++ b/frames/src/test/java/com/checkout/frames/component/expirydate/ExpiryDateVisualTransformationTest.kt
@@ -2,6 +2,7 @@ package com.checkout.frames.component.expirydate
 
 import android.annotation.SuppressLint
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import io.mockk.junit5.MockKExtension
 import org.amshove.kluent.internal.assertEquals
@@ -11,6 +12,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
 
 @SuppressLint("NewApi")
 @ExtendWith(MockKExtension::class)
@@ -41,6 +44,26 @@ internal class ExpiryDateVisualTransformationTest {
         // Then
         assertEquals(transformedExpiryDate, result)
     }
+    @Test
+    fun `verify offsetMapping for 123`() {
+        val result = expiryDateVisualTransformation.filter(AnnotatedString("123"))
+        assertCorrectMapping(original = "123", result)
+    }
+    @Test
+    fun `verify offsetMapping for 143`() {
+        val result = expiryDateVisualTransformation.filter(AnnotatedString("143"))
+        assertCorrectMapping(original = "143", result)
+    }
+    @Test
+    fun `verify offsetMapping for 093`() {
+        val result = expiryDateVisualTransformation.filter(AnnotatedString("093"))
+        assertCorrectMapping(original = "093", result)
+    }
+    @Test
+    fun `verify offsetMapping for 53`() {
+        val result = expiryDateVisualTransformation.filter(AnnotatedString("53"))
+        assertCorrectMapping(original = "53", result)
+    }
 
     companion object {
         @JvmStatic
@@ -64,5 +87,22 @@ internal class ExpiryDateVisualTransformationTest {
             Arguments.of("9", "09 / "),
             Arguments.of("856", "08 / 56"),
         )
+    }
+
+    private fun assertCorrectMapping(
+        original: String,
+        result: TransformedText,
+    ) {
+        val transformed = result.text.text
+
+        for (offset in 0..original.length) {
+            val transformedOffset = result.offsetMapping.originalToTransformed(offset)
+            assertThat(transformedOffset).isIn(0..transformed.length)
+        }
+
+        for (offset in 0..result.text.text.length) {
+            val originalOffset = result.offsetMapping.transformedToOriginal(offset)
+            assertThat(originalOffset).isIn(0..original.length)
+        }
     }
 }

--- a/frames/src/test/java/com/checkout/frames/screen/billingaddressdetails/models/BillingAddressTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/billingaddressdetails/models/BillingAddressTest.kt
@@ -10,8 +10,6 @@ import org.amshove.kluent.internal.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-
-
 internal class BillingAddressTest {
     @Test
     fun `A default BillingAddress should not be edited`() = assertFalse(BillingAddress().isEdited())


### PR DESCRIPTION
## Issue

[PIMOB-2040](https://checkout.atlassian.net/browse/PIMOB-2040)

## Proposed changes
ExpiryDateVisualTransformation returned an incorrect mapping between transformed and original offsets resulting in a crash. So, added robust logic to resolve it


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Reviewers assigned
* [X] I have performed a self-review of my code and manual testing
* [X] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered, etc...


[PIMOB-2040]: https://checkout.atlassian.net/browse/PIMOB-2040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ