### PR TITLE
PIMOB:1634- CardHolder Name component was added in paymentForm

### DIFF
--- a/frames/src/main/java/com/checkout/frames/component/cardholdername/CardHolderNameComponent.kt
+++ b/frames/src/main/java/com/checkout/frames/component/cardholdername/CardHolderNameComponent.kt
@@ -1,0 +1,23 @@
+package com.checkout.frames.component.cardholdername
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.checkout.frames.component.base.InputComponent
+import com.checkout.frames.di.base.Injector
+import com.checkout.frames.style.component.CardHolderNameComponentStyle
+
+@Composable
+internal fun CardHolderNameComponent(
+    style: CardHolderNameComponentStyle,
+    injector: Injector
+) {
+    val viewModel: CardHolderNameViewModel = viewModel(
+        factory = CardHolderNameViewModel.Factory(injector, style)
+    )
+
+    InputComponent(
+        style = viewModel.componentStyle,
+        state = viewModel.componentState.inputState,
+        onValueChange = viewModel::onCardHolderNameChange
+    )
+}

--- a/frames/src/main/java/com/checkout/frames/component/cardholdername/CardHolderNameComponentState.kt
+++ b/frames/src/main/java/com/checkout/frames/component/cardholdername/CardHolderNameComponentState.kt
@@ -1,0 +1,9 @@
+package com.checkout.frames.component.cardholdername
+
+import com.checkout.frames.component.base.InputComponentState
+
+internal data class CardHolderNameComponentState(
+    val inputState: InputComponentState
+) {
+    val cardHolderName = inputState.inputFieldState.text
+}

--- a/frames/src/main/java/com/checkout/frames/component/cardholdername/CardHolderNameViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/component/cardholdername/CardHolderNameViewModel.kt
@@ -1,0 +1,66 @@
+package com.checkout.frames.component.cardholdername
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.ImeAction
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.checkout.base.mapper.Mapper
+import com.checkout.frames.component.base.InputComponentState
+import com.checkout.frames.di.base.InjectionClient
+import com.checkout.frames.di.base.Injector
+import com.checkout.frames.di.component.CardHolderNameViewModelSubComponent
+import com.checkout.frames.style.component.CardHolderNameComponentStyle
+import com.checkout.frames.style.component.base.InputComponentStyle
+import com.checkout.frames.style.view.InputComponentViewStyle
+import javax.inject.Inject
+import javax.inject.Provider
+
+internal class CardHolderNameViewModel @Inject constructor(
+    private val inputComponentStyleMapper: Mapper<InputComponentStyle, InputComponentViewStyle>,
+    private val inputComponentStateMapper: Mapper<InputComponentStyle, InputComponentState>,
+    style: CardHolderNameComponentStyle,
+) : ViewModel() {
+
+    val componentState = provideViewState(style)
+    val componentStyle = provideViewStyle(style.inputStyle)
+
+    internal companion object {
+        val nameRegex = "[^a-zA-Z'\\s-]".toRegex()
+    }
+
+    fun onCardHolderNameChange(text: String) = with(text.replace(nameRegex, "")) {
+        componentState.cardHolderName.value = this.trim()
+    }
+
+    private fun provideViewState(style: CardHolderNameComponentStyle): CardHolderNameComponentState {
+        return CardHolderNameComponentState(inputComponentStateMapper.map(style.inputStyle))
+    }
+
+    private fun provideViewStyle(inputStyle: InputComponentStyle): InputComponentViewStyle {
+        var viewStyle = inputComponentStyleMapper.map(inputStyle)
+        val keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
+
+        viewStyle = viewStyle.copy(
+            inputFieldStyle = viewStyle.inputFieldStyle.copy(
+                keyboardOptions = keyboardOptions, forceLTR = true
+            )
+        )
+
+        return viewStyle
+    }
+
+    internal class Factory(
+        private val injector: Injector,
+        private val style: CardHolderNameComponentStyle,
+    ) : ViewModelProvider.Factory, InjectionClient {
+
+        @Inject
+        lateinit var subComponentProvider: Provider<CardHolderNameViewModelSubComponent.Builder>
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            injector.inject(this)
+            return subComponentProvider.get().style(style).build().cardHolderNameViewModel as T
+        }
+    }
+}

--- a/frames/src/main/java/com/checkout/frames/component/provider/ComponentProvider.kt
+++ b/frames/src/main/java/com/checkout/frames/component/provider/ComponentProvider.kt
@@ -1,6 +1,7 @@
 package com.checkout.frames.component.provider
 
 import androidx.compose.runtime.Composable
+import com.checkout.frames.style.component.CardHolderNameComponentStyle
 import com.checkout.frames.style.component.CardNumberComponentStyle
 import com.checkout.frames.style.component.CardSchemeComponentStyle
 import com.checkout.frames.style.component.CvvComponentStyle
@@ -11,6 +12,9 @@ import com.checkout.frames.style.component.addresssummary.AddressSummaryComponen
 internal interface ComponentProvider {
     @Composable
     fun CardScheme(style: CardSchemeComponentStyle)
+
+    @Composable
+    fun CardHolderName(style: CardHolderNameComponentStyle)
 
     @Composable
     fun CardNumber(style: CardNumberComponentStyle)

--- a/frames/src/main/java/com/checkout/frames/component/provider/ComposableComponentProvider.kt
+++ b/frames/src/main/java/com/checkout/frames/component/provider/ComposableComponentProvider.kt
@@ -2,12 +2,14 @@ package com.checkout.frames.component.provider
 
 import androidx.compose.runtime.Composable
 import com.checkout.frames.component.addresssummary.AddressSummaryComponent
+import com.checkout.frames.component.cardholdername.CardHolderNameComponent
 import com.checkout.frames.component.cardnumber.CardNumberComponent
 import com.checkout.frames.component.cardscheme.CardSchemeComponent
 import com.checkout.frames.component.cvv.CvvComponent
 import com.checkout.frames.component.expirydate.ExpiryDateComponent
 import com.checkout.frames.component.paybutton.PayButtonComponent
 import com.checkout.frames.di.base.Injector
+import com.checkout.frames.style.component.CardHolderNameComponentStyle
 import com.checkout.frames.style.component.CardNumberComponentStyle
 import com.checkout.frames.style.component.CardSchemeComponentStyle
 import com.checkout.frames.style.component.CvvComponentStyle
@@ -22,6 +24,11 @@ internal class ComposableComponentProvider(
     @Composable
     override fun CardScheme(style: CardSchemeComponentStyle) {
       CardSchemeComponent(style, injector)
+    }
+
+    @Composable
+    override fun CardHolderName(style: CardHolderNameComponentStyle) {
+        CardHolderNameComponent(style, injector)
     }
 
     @Composable

--- a/frames/src/main/java/com/checkout/frames/di/component/CardHolderNameViewModelSubComponent.kt
+++ b/frames/src/main/java/com/checkout/frames/di/component/CardHolderNameViewModelSubComponent.kt
@@ -1,0 +1,19 @@
+package com.checkout.frames.di.component
+
+import com.checkout.frames.component.cardholdername.CardHolderNameViewModel
+import com.checkout.frames.style.component.CardHolderNameComponentStyle
+import dagger.BindsInstance
+import dagger.Subcomponent
+
+@Subcomponent
+internal interface CardHolderNameViewModelSubComponent {
+    val cardHolderNameViewModel: CardHolderNameViewModel
+
+    @Subcomponent.Builder
+    interface Builder {
+        @BindsInstance
+        fun style(style: CardHolderNameComponentStyle): Builder
+
+        fun build(): CardHolderNameViewModelSubComponent
+    }
+}

--- a/frames/src/main/java/com/checkout/frames/di/component/FramesDIComponent.kt
+++ b/frames/src/main/java/com/checkout/frames/di/component/FramesDIComponent.kt
@@ -3,6 +3,7 @@ package com.checkout.frames.di.component
 import com.checkout.base.model.CardScheme
 import com.checkout.frames.component.addresssummary.AddressSummaryViewModel
 import com.checkout.base.usecase.UseCase
+import com.checkout.frames.component.cardholdername.CardHolderNameViewModel
 import com.checkout.frames.component.cardnumber.CardNumberViewModel
 import com.checkout.frames.component.cardscheme.CardSchemeViewModel
 import com.checkout.frames.component.country.CountryViewModel
@@ -38,6 +39,7 @@ internal abstract class FramesDIComponent {
 
     /** Component **/
     abstract fun inject(factory: CardNumberViewModel.Factory)
+    abstract fun inject(factory: CardHolderNameViewModel.Factory)
     abstract fun inject(factory: CvvViewModel.Factory)
     abstract fun inject(factory: ExpiryDateViewModel.Factory)
     abstract fun inject(factory: CardSchemeViewModel.Factory)

--- a/frames/src/main/java/com/checkout/frames/di/injector/FramesInjector.kt
+++ b/frames/src/main/java/com/checkout/frames/di/injector/FramesInjector.kt
@@ -22,6 +22,7 @@ import com.checkout.frames.screen.countrypicker.CountryPickerViewModel
 import com.checkout.frames.screen.paymentdetails.PaymentDetailsViewModel
 import com.checkout.frames.screen.paymentform.PaymentFormViewModel
 import com.checkout.frames.api.PaymentFlowHandler
+import com.checkout.frames.component.cardholdername.CardHolderNameViewModel
 import com.checkout.frames.usecase.CardTokenizationUseCase
 import com.checkout.frames.usecase.ClosePaymentFlowUseCase
 import com.checkout.frames.utils.extensions.logEvent
@@ -32,6 +33,7 @@ internal class FramesInjector(private val component: FramesDIComponent) : Inject
     override fun inject(client: InjectionClient) {
         when (client) {
             is CardNumberViewModel.Factory -> component.inject(client)
+            is CardHolderNameViewModel.Factory -> component.inject(client)
             is ExpiryDateViewModel.Factory -> component.inject(client)
             is CvvViewModel.Factory -> component.inject(client)
             is PaymentDetailsViewModel.Factory -> component.inject(client)

--- a/frames/src/main/java/com/checkout/frames/di/module/PaymentModule.kt
+++ b/frames/src/main/java/com/checkout/frames/di/module/PaymentModule.kt
@@ -4,6 +4,7 @@ import com.checkout.base.model.CardScheme
 import com.checkout.frames.di.component.CardSchemeViewModelSubComponent
 import com.checkout.frames.di.component.AddressSummaryViewModelSubComponent
 import com.checkout.frames.di.component.BillingFormViewModelSubComponent
+import com.checkout.frames.di.component.CardHolderNameViewModelSubComponent
 import com.checkout.frames.di.component.CardNumberViewModelSubComponent
 import com.checkout.frames.di.component.CountryPickerViewModelSubComponent
 import com.checkout.frames.di.component.CountryViewModelSubComponent
@@ -19,6 +20,7 @@ import javax.inject.Singleton
 @Module(
     subcomponents = [
         CardNumberViewModelSubComponent::class,
+        CardHolderNameViewModelSubComponent::class,
         CvvViewModelSubComponent::class,
         ExpiryDateViewModelSubComponent::class,
         PaymentDetailsViewModelSubComponent::class,

--- a/frames/src/main/java/com/checkout/frames/di/module/StylesModule.kt
+++ b/frames/src/main/java/com/checkout/frames/di/module/StylesModule.kt
@@ -5,6 +5,7 @@ import com.checkout.base.mapper.Mapper
 import com.checkout.frames.component.base.InputComponentState
 import com.checkout.frames.di.component.AddressSummaryViewModelSubComponent
 import com.checkout.frames.di.component.BillingFormViewModelSubComponent
+import com.checkout.frames.di.component.CardHolderNameViewModelSubComponent
 import com.checkout.frames.di.component.CardNumberViewModelSubComponent
 import com.checkout.frames.di.component.CountryPickerViewModelSubComponent
 import com.checkout.frames.di.component.CountryViewModelSubComponent
@@ -42,6 +43,7 @@ import dagger.Provides
 @Module(
     subcomponents = [
         CardNumberViewModelSubComponent::class,
+        CardHolderNameViewModelSubComponent::class,
         ExpiryDateViewModelSubComponent::class,
         CvvViewModelSubComponent::class,
         PaymentDetailsViewModelSubComponent::class,

--- a/frames/src/main/java/com/checkout/frames/mapper/theme/PaymentDetailsStyleMapper.kt
+++ b/frames/src/main/java/com/checkout/frames/mapper/theme/PaymentDetailsStyleMapper.kt
@@ -5,6 +5,7 @@ import com.checkout.frames.R
 import com.checkout.frames.model.BorderStroke
 import com.checkout.frames.model.Margin
 import com.checkout.frames.model.Padding
+import com.checkout.frames.style.component.CardHolderNameComponentStyle
 import com.checkout.frames.style.component.CardSchemeComponentStyle
 import com.checkout.frames.style.component.CardNumberComponentStyle
 import com.checkout.frames.style.component.CvvComponentStyle
@@ -16,6 +17,7 @@ import com.checkout.frames.style.component.base.ContainerStyle
 import com.checkout.frames.style.component.base.TextLabelStyle
 import com.checkout.frames.style.component.default.DefaultCvvComponentStyle
 import com.checkout.frames.style.component.default.DefaultAddressSummaryComponentStyle
+import com.checkout.frames.style.component.default.DefaultCardHolderNameComponentStyle
 import com.checkout.frames.style.component.default.DefaultCardNumberComponentStyle
 import com.checkout.frames.style.component.default.DefaultExpiryDateComponentStyle
 import com.checkout.frames.style.component.default.DefaultPayButtonComponentStyle
@@ -38,12 +40,13 @@ import com.checkout.frames.utils.extensions.provideText
 import com.checkout.frames.utils.extensions.provideTextId
 import com.checkout.frames.utils.extensions.provideTitleStyle
 import com.checkout.frames.utils.extensions.provideTitleTextStyle
-
+@Suppress("TooManyFunctions")
 internal class PaymentDetailsStyleMapper : Mapper<PaymentFormTheme, PaymentDetailsStyle> {
 
     override fun map(from: PaymentFormTheme) = PaymentDetailsStyle(
         paymentDetailsHeaderStyle = providePaymentDetailsHeaderStyle(from),
         cardSchemeStyle = provideCardSchemeStyle(from),
+        cardHolderNameComponentStyle = provideCardHolderNameStyle(from),
         cardNumberStyle = provideCardNumberStyle(from),
         expiryDateStyle = provideExpiryDateStyle(from),
         cvvStyle = provideCVVStyle(from),
@@ -212,6 +215,27 @@ internal class PaymentDetailsStyleMapper : Mapper<PaymentFormTheme, PaymentDetai
             )
         }
         return cvvComponentStyle
+    }
+
+    private fun provideCardHolderNameStyle(from: PaymentFormTheme): CardHolderNameComponentStyle {
+        var cardHolderNameStyle = DefaultCardHolderNameComponentStyle.light()
+        val paymentFormComponent = from.paymentFormComponents.find {
+            PaymentFormComponentField.CardHolderName.name == it.paymentFormComponentField.name
+        }
+        paymentFormComponent?.let { component ->
+            cardHolderNameStyle = cardHolderNameStyle.copy(
+                inputStyle = with(cardHolderNameStyle.inputStyle) {
+                    this.copy(
+                        titleStyle = titleStyle.provideTitleStyle(component, from),
+                        subtitleStyle = subtitleStyle.provideSubTitleStyle(component, from),
+                        inputFieldStyle = provideInputFieldStyle(from),
+                        errorMessageStyle = errorMessageStyle.provideErrorMessageStyle(from),
+                        isInputFieldOptional = component.isFieldOptional
+                    )
+                }
+            )
+        }
+        return cardHolderNameStyle
     }
 
     private fun provideExpiryDateStyle(from: PaymentFormTheme): ExpiryDateComponentStyle {

--- a/frames/src/main/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsScreen.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsScreen.kt
@@ -51,6 +51,9 @@ internal fun PaymentDetailsScreen(
             // Cards schemes
             viewModel.componentProvider.CardScheme(style = style.cardSchemeStyle)
 
+            // Card holder Name
+            viewModel.componentProvider.CardHolderName(style = style.cardHolderNameComponentStyle)
+
             // Card Number
             viewModel.componentProvider.CardNumber(style = style.cardNumberStyle)
 

--- a/frames/src/main/java/com/checkout/frames/style/component/CardHolderNameComponentStyle.kt
+++ b/frames/src/main/java/com/checkout/frames/style/component/CardHolderNameComponentStyle.kt
@@ -1,0 +1,7 @@
+package com.checkout.frames.style.component
+
+import com.checkout.frames.style.component.base.InputComponentStyle
+
+public data class CardHolderNameComponentStyle(
+    var inputStyle: InputComponentStyle = InputComponentStyle()
+)

--- a/frames/src/main/java/com/checkout/frames/style/component/default/DefaultCardHolderNameComponentStyle.kt
+++ b/frames/src/main/java/com/checkout/frames/style/component/default/DefaultCardHolderNameComponentStyle.kt
@@ -1,0 +1,18 @@
+package com.checkout.frames.style.component.default
+
+import com.checkout.frames.R
+import com.checkout.frames.model.Margin
+import com.checkout.frames.style.component.CardHolderNameComponentStyle
+import com.checkout.frames.utils.constants.PaymentDetailsScreenConstants.marginBottom
+
+public object DefaultCardHolderNameComponentStyle {
+
+    public fun light(): CardHolderNameComponentStyle {
+        val style = DefaultLightStyle.inputComponentStyle(
+            titleTextId = R.string.cko_card_holder_name_title,
+            infoTextId = R.string.cko_input_field_optional_info,
+            margin = Margin(bottom = marginBottom)
+        )
+        return CardHolderNameComponentStyle(style)
+    }
+}

--- a/frames/src/main/java/com/checkout/frames/style/screen/PaymentDetailsStyle.kt
+++ b/frames/src/main/java/com/checkout/frames/style/screen/PaymentDetailsStyle.kt
@@ -2,6 +2,7 @@ package com.checkout.frames.style.screen
 
 import com.checkout.frames.R
 import com.checkout.frames.model.Padding
+import com.checkout.frames.style.component.CardHolderNameComponentStyle
 import com.checkout.frames.style.component.CardNumberComponentStyle
 import com.checkout.frames.style.component.PayButtonComponentStyle
 import com.checkout.frames.style.component.CardSchemeComponentStyle
@@ -15,6 +16,7 @@ import com.checkout.frames.style.component.default.DefaultCvvComponentStyle
 import com.checkout.frames.style.component.default.DefaultExpiryDateComponentStyle
 import com.checkout.frames.style.component.default.DefaultLightStyle
 import com.checkout.frames.style.component.default.DefaultAddressSummaryComponentStyle
+import com.checkout.frames.style.component.default.DefaultCardHolderNameComponentStyle
 import com.checkout.frames.style.component.default.DefaultPayButtonComponentStyle
 import com.checkout.frames.utils.constants.PaymentDetailsScreenConstants
 
@@ -24,6 +26,7 @@ public data class PaymentDetailsStyle @JvmOverloads constructor(
         imageId = R.drawable.cko_ic_arrow_back
     ),
     public var cardSchemeStyle: CardSchemeComponentStyle = DefaultLightStyle.cardSchemeComponentStyle(),
+    public var cardHolderNameComponentStyle: CardHolderNameComponentStyle = DefaultCardHolderNameComponentStyle.light(),
     public var cardNumberStyle: CardNumberComponentStyle = DefaultCardNumberComponentStyle.light(),
     public var expiryDateStyle: ExpiryDateComponentStyle = DefaultExpiryDateComponentStyle.light(),
     public var cvvStyle: CvvComponentStyle? = DefaultCvvComponentStyle.light(),

--- a/frames/src/main/java/com/checkout/frames/style/theme/PaymentFormComponentField.kt
+++ b/frames/src/main/java/com/checkout/frames/style/theme/PaymentFormComponentField.kt
@@ -6,6 +6,7 @@ package com.checkout.frames.style.theme
 public enum class PaymentFormComponentField {
     PaymentHeaderTitle,
     CardScheme,
+    CardHolderName,
     CardNumber,
     ExpiryDate,
     CVV,

--- a/frames/src/main/res/values-ar/strings.xml
+++ b/frames/src/main/res/values-ar/strings.xml
@@ -33,4 +33,5 @@
     <string name="cko_billing_form_input_field_state">المنطقة</string>
     <string name="cko_billing_form_input_field_postcode">الرمز البريدي</string>
     <string name="cko_billing_form_input_field_phone_country_error">يُرجى إختيار الدولة</string>
+    <string name="cko_card_holder_name_title">إسم حامل البطاقة</string>
 </resources>

--- a/frames/src/main/res/values-de/strings.xml
+++ b/frames/src/main/res/values-de/strings.xml
@@ -33,4 +33,5 @@
     <string name="cko_billing_form_input_field_state">Bundesland</string>
     <string name="cko_billing_form_input_field_postcode">Postleitzahl</string>
     <string name="cko_billing_form_input_field_phone_country_error">Fehlendes Land</string>
+    <string name="cko_card_holder_name_title">Name der Karteninhaberin / des Karteninhabers</string>
 </resources>

--- a/frames/src/main/res/values-es/strings.xml
+++ b/frames/src/main/res/values-es/strings.xml
@@ -33,4 +33,5 @@
     <string name="cko_billing_form_input_field_state">Comunidad Autónoma</string>
     <string name="cko_billing_form_input_field_postcode">Código postal</string>
     <string name="cko_billing_form_input_field_phone_country_error">Selecciona tu país</string>
+    <string name="cko_card_holder_name_title">Nombre del titular</string>
 </resources>

--- a/frames/src/main/res/values-fr/strings.xml
+++ b/frames/src/main/res/values-fr/strings.xml
@@ -33,4 +33,5 @@
     <string name="cko_billing_form_input_field_state">Département</string>
     <string name="cko_billing_form_input_field_postcode">Code postal</string>
     <string name="cko_billing_form_input_field_phone_country_error">Pays manquant</string>
+    <string name="cko_card_holder_name_title">Nom du titulaire de la carte</string>
 </resources>

--- a/frames/src/main/res/values-it/strings.xml
+++ b/frames/src/main/res/values-it/strings.xml
@@ -33,4 +33,5 @@
     <string name="cko_billing_form_input_field_state">Regione</string>
     <string name="cko_billing_form_input_field_postcode">Codice postale</string>
     <string name="cko_billing_form_input_field_phone_country_error">Paese scomparso</string>
+    <string name="cko_card_holder_name_title">Nome del titolare</string>
 </resources>

--- a/frames/src/main/res/values-nl/strings.xml
+++ b/frames/src/main/res/values-nl/strings.xml
@@ -33,4 +33,5 @@
     <string name="cko_billing_form_input_field_state">Provincie</string>
     <string name="cko_billing_form_input_field_postcode">Postcode</string>
     <string name="cko_billing_form_input_field_phone_country_error">" Ontbrekend land"</string>
+    <string name="cko_card_holder_name_title">Naam pashouder</string>
 </resources>

--- a/frames/src/main/res/values-ro/strings.xml
+++ b/frames/src/main/res/values-ro/strings.xml
@@ -33,4 +33,5 @@
     <string name="cko_billing_form_input_field_state">Județ</string>
     <string name="cko_billing_form_input_field_postcode">Codul poștal</string>
     <string name="cko_billing_form_input_field_phone_country_error">Alegeți țara</string>
+    <string name="cko_card_holder_name_title">Nume deţinător card</string>
 </resources>

--- a/frames/src/main/res/values/strings.xml
+++ b/frames/src/main/res/values/strings.xml
@@ -14,6 +14,9 @@
     <string name="cko_card_number_title" translatable="true">Card number</string>
     <string name="cko_base_invalid_card_number_error" translatable="true">Please enter a valid card number.</string>
 
+    <!--Card holder name component-->
+    <string name="cko_card_holder_name_title" translatable="true">Cardholder name</string>
+
     <!--Card number component-->
     <string name="cko_accepted_cards_title" translatable="true">Accepted cards:</string>
 

--- a/frames/src/test/java/com/checkout/frames/component/cardholdername/CardHolderNameViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/component/cardholdername/CardHolderNameViewModelTest.kt
@@ -1,0 +1,136 @@
+package com.checkout.frames.component.cardholdername
+
+import android.annotation.SuppressLint
+import com.checkout.base.mapper.Mapper
+import com.checkout.frames.component.base.InputComponentState
+import com.checkout.frames.mapper.ContainerStyleToModifierMapper
+import com.checkout.frames.mapper.TextLabelStyleToViewStyleMapper
+import com.checkout.frames.mapper.ImageStyleToComposableImageMapper
+import com.checkout.frames.mapper.InputComponentStyleToViewStyleMapper
+import com.checkout.frames.mapper.InputFieldStyleToViewStyleMapper
+import com.checkout.frames.mapper.InputComponentStyleToStateMapper
+import com.checkout.frames.mapper.InputFieldStyleToInputFieldStateMapper
+import com.checkout.frames.mapper.TextLabelStyleToStateMapper
+import com.checkout.frames.style.component.CardHolderNameComponentStyle
+import com.checkout.frames.style.component.base.InputComponentStyle
+import com.checkout.frames.style.view.InputComponentViewStyle
+import io.mockk.impl.annotations.SpyK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+@SuppressLint("NewApi")
+@ExtendWith(MockKExtension::class)
+internal class CardHolderNameViewModelTest {
+
+    @SpyK
+    lateinit var spyInputComponentStyleMapper: Mapper<InputComponentStyle, InputComponentViewStyle>
+
+    @SpyK
+    lateinit var spyInputComponentStateMapper: Mapper<InputComponentStyle, InputComponentState>
+
+    private var style: CardHolderNameComponentStyle = CardHolderNameComponentStyle()
+
+    private lateinit var viewModel: CardHolderNameViewModel
+
+    init {
+        initMappers()
+    }
+
+    @BeforeEach
+    fun setUp() {
+        viewModel = CardHolderNameViewModel(
+            spyInputComponentStyleMapper, spyInputComponentStateMapper, style
+        )
+    }
+
+    /** Initial state tests **/
+
+    @Test
+    fun `when view model is initialised then component style is mapped to initial component state`() {
+        // Then
+        verify { spyInputComponentStateMapper.map(style.inputStyle) }
+    }
+
+    @Test
+    fun `when view model is initialised then initial state has empty card holder name`() {
+        // Then
+        assertTrue(viewModel.componentState.cardHolderName.value.isEmpty())
+    }
+
+    /** Initial style tests **/
+
+    @Test
+    fun `when view model is initialised then component style is mapped to initial component view style`() {
+        // Then
+        verify { spyInputComponentStyleMapper.map(style.inputStyle) }
+    }
+
+    @Test
+    fun `when view model is initialised then initial style has forced LTR`() {
+        // Then
+        assertTrue(viewModel.componentStyle.inputFieldStyle.forceLTR)
+    }
+
+    /** Input data filtering **/
+
+    @Test
+    fun `when card holder name with special characters and digits entered then these symbols are removed`() {
+        // Given
+        val sourceInput = "Denny@123"
+        val filteredInput = "Denny"
+
+        // When
+        viewModel.onCardHolderNameChange(sourceInput)
+
+        // Then
+        assertEquals(viewModel.componentState.cardHolderName.value, filteredInput)
+    }
+
+    @ParameterizedTest(
+        name = "When on card holder name change invoked with {0} then {1} set to text field state"
+    )
+    @MethodSource("onTextChangedArguments")
+    fun `When on card holder name change invoked with a string then cleaned string should be set to a text field state`(
+        enteredText: String,
+        cleanedText: String,
+    ) {
+        // When
+        viewModel.onCardHolderNameChange(enteredText)
+
+        // Then
+        assertEquals(viewModel.componentState.cardHolderName.value, cleanedText)
+    }
+
+    private fun initMappers() {
+        val containerMapper = ContainerStyleToModifierMapper()
+        val textLabelStyleMapper = TextLabelStyleToViewStyleMapper(containerMapper)
+        val imageMapper = ImageStyleToComposableImageMapper()
+
+        spyInputComponentStyleMapper = InputComponentStyleToViewStyleMapper(
+            textLabelStyleMapper, InputFieldStyleToViewStyleMapper(textLabelStyleMapper), containerMapper
+        )
+        spyInputComponentStateMapper = InputComponentStyleToStateMapper(
+            TextLabelStyleToStateMapper(imageMapper), InputFieldStyleToInputFieldStateMapper(imageMapper)
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        fun onTextChangedArguments(): Stream<Arguments> = Stream.of(
+            Arguments.of("TestName_£Charles", "TestNameCharles"),
+            Arguments.of("TestName's Charles123 ", "TestName's Charles"),
+            Arguments.of("TestName31343443243424324 ", "TestName"),
+            Arguments.of("TestName's %$3%Charles", "TestName's Charles"),
+            Arguments.of("TestName's&^$£$$$%% %$3%Charles", "TestName's Charles")
+        )
+    }
+}


### PR DESCRIPTION
## Issue

[PIMOB-2084](https://checkout.atlassian.net/browse/PIMOB-2084)

## Proposed changes

- Add CardHolder Name Components into the Payment form and it should be optional
- Add cardholder name regex for valid name. Currently applied same as IOS. For instance, Match any character that is either a letter (uppercase or lowercase), an apostrophe, a space, or a hyphen. for instance, Mark’s - Zenburg
- Added multi-language strings for cardholder name
- Added test cases


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Reviewers assigned
* [X] I have performed a self-review of my code and manual testing
* [X] Lint and unit tests pass locally with my changes
* [X] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered, etc...
