### PR TITLE
PIMOB-2093: Injected prefilled billing-form address in paymentformconfig

### DIFF
--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/MainActivity.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/MainActivity.kt
@@ -9,23 +9,20 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.checkout.base.model.CardScheme
-import com.checkout.base.model.Country
 import com.checkout.example.frames.navigation.Screen
 import com.checkout.example.frames.paymentformstyling.CustomBillingFormStyle
 import com.checkout.example.frames.paymentformstyling.CustomPaymentDetailsStyle
 import com.checkout.example.frames.paymentformstyling.CustomPaymentFormTheme
 import com.checkout.example.frames.ui.utils.ENVIRONMENT
 import com.checkout.example.frames.ui.utils.PUBLIC_KEY
+import com.checkout.example.frames.ui.utils.PrefillDataHelper
 import com.checkout.frames.R
 import com.checkout.frames.screen.paymentform.model.PaymentFormConfig
 import com.checkout.frames.api.PaymentFormMediator
 import com.checkout.frames.style.screen.PaymentFormStyle
 import com.checkout.frames.api.PaymentFlowHandler
-import com.checkout.frames.screen.paymentform.model.BillingFormAddress
 import com.checkout.frames.screen.paymentform.model.PrefillData
 import com.checkout.frames.style.theme.paymentform.PaymentFormStyleProvider
-import com.checkout.tokenization.model.Address
-import com.checkout.tokenization.model.Phone
 import com.checkout.tokenization.model.TokenDetails
 
 class MainActivity : ComponentActivity() {
@@ -72,20 +69,7 @@ fun Navigator(
             CardScheme.MAESTRO,
             CardScheme.AMERICAN_EXPRESS
         ),
-        prefillData = PrefillData(
-            cardHolderName = "Test Name",
-            billingFormAddress = BillingFormAddress(
-                address = Address(
-                    addressLine1 = "Checkout.com",
-                    addressLine2 = "90 Tottenham Court Road",
-                    city = "London",
-                    state = "London",
-                    zip = "W1T 4TJ",
-                    country = Country.from(iso3166Alpha2 = "GB")
-                ),
-                phone = Phone("7405987323", Country.UNITED_KINGDOM)
-            )
-        )
+        prefillData = PrefillDataHelper.prefillData
     )
     val defaultPaymentFormMediator = PaymentFormMediator(defaultPaymentFormConfig)
 
@@ -107,18 +91,9 @@ fun Navigator(
                 CardScheme.MASTERCARD,
                 CardScheme.AMERICAN_EXPRESS
             ),
-            prefillData = PrefillData(
-                billingFormAddress = BillingFormAddress(
-                    name = "Test name",
-                    address = Address(
-                        addressLine1 = "Checkout.com",
-                        addressLine2 = "90 Tottenham Court Road",
-                        city = "London",
-                        state = "London",
-                        zip = "W1T 4TJ",
-                        country = Country.from(iso3166Alpha2 = "GB")
-                    ),
-                    phone = Phone("7405987323", Country.UNITED_KINGDOM)
+            prefillData = PrefillDataHelper.prefillData.copy(
+                billingFormAddress = PrefillDataHelper.prefillData.billingFormAddress?.copy(
+                    name = "Test name"
                 )
             )
         )

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/MainActivity.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.checkout.base.model.CardScheme
+import com.checkout.base.model.Country
 import com.checkout.example.frames.navigation.Screen
 import com.checkout.example.frames.paymentformstyling.CustomBillingFormStyle
 import com.checkout.example.frames.paymentformstyling.CustomPaymentDetailsStyle
@@ -20,8 +21,11 @@ import com.checkout.frames.screen.paymentform.model.PaymentFormConfig
 import com.checkout.frames.api.PaymentFormMediator
 import com.checkout.frames.style.screen.PaymentFormStyle
 import com.checkout.frames.api.PaymentFlowHandler
+import com.checkout.frames.screen.paymentform.model.BillingFormAddress
 import com.checkout.frames.screen.paymentform.model.PrefillData
 import com.checkout.frames.style.theme.paymentform.PaymentFormStyleProvider
+import com.checkout.tokenization.model.Address
+import com.checkout.tokenization.model.Phone
 import com.checkout.tokenization.model.TokenDetails
 
 class MainActivity : ComponentActivity() {
@@ -37,6 +41,7 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+@Suppress("LongMethod")
 @Composable
 fun Navigator(
     context: Context,
@@ -66,6 +71,20 @@ fun Navigator(
             CardScheme.MASTERCARD,
             CardScheme.MAESTRO,
             CardScheme.AMERICAN_EXPRESS
+        ),
+        prefillData = PrefillData(
+            cardHolderName = "Test Name",
+            billingFormAddress = BillingFormAddress(
+                address = Address(
+                    addressLine1 = "Checkout.com",
+                    addressLine2 = "90 Tottenham Court Road",
+                    city = "London",
+                    state = "London",
+                    zip = "W1T 4TJ",
+                    country = Country.from(iso3166Alpha2 = "GB")
+                ),
+                phone = Phone("7405987323", Country.UNITED_KINGDOM)
+            )
         )
     )
     val defaultPaymentFormMediator = PaymentFormMediator(defaultPaymentFormConfig)
@@ -87,6 +106,20 @@ fun Navigator(
                 CardScheme.VISA,
                 CardScheme.MASTERCARD,
                 CardScheme.AMERICAN_EXPRESS
+            ),
+            prefillData = PrefillData(
+                billingFormAddress = BillingFormAddress(
+                    name = "Test name",
+                    address = Address(
+                        addressLine1 = "Checkout.com",
+                        addressLine2 = "90 Tottenham Court Road",
+                        city = "London",
+                        state = "London",
+                        zip = "W1T 4TJ",
+                        country = Country.from(iso3166Alpha2 = "GB")
+                    ),
+                    phone = Phone("7405987323", Country.UNITED_KINGDOM)
+                )
             )
         )
     )

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/utils/PrefillDataHelper.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/utils/PrefillDataHelper.kt
@@ -1,0 +1,24 @@
+package com.checkout.example.frames.ui.utils
+
+import com.checkout.base.model.Country
+import com.checkout.frames.screen.paymentform.model.BillingFormAddress
+import com.checkout.frames.screen.paymentform.model.PrefillData
+import com.checkout.tokenization.model.Address
+import com.checkout.tokenization.model.Phone
+
+internal object PrefillDataHelper {
+    val prefillData = PrefillData(
+        cardHolderName = "Test Name",
+        billingFormAddress = BillingFormAddress(
+            address = Address(
+                addressLine1 = "Checkout.com",
+                addressLine2 = "90 Tottenham Court Road",
+                city = "London",
+                state = "London",
+                zip = "W1T 4TJ",
+                country = Country.from(iso3166Alpha2 = "GB")
+            ),
+            phone = Phone("7405987323", Country.UNITED_KINGDOM)
+        )
+    )
+}

--- a/frames/src/androidTest/kotlin/com/checkout/frames/screen/paymentform/PaymentFormScreenTest.kt
+++ b/frames/src/androidTest/kotlin/com/checkout/frames/screen/paymentform/PaymentFormScreenTest.kt
@@ -1,0 +1,72 @@
+package com.checkout.frames.screen.paymentform
+
+import android.content.Context
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.checkout.base.model.CardScheme
+import com.checkout.base.model.Country
+import com.checkout.base.model.Environment
+import com.checkout.frames.api.PaymentFlowHandler
+import com.checkout.frames.screen.paymentform.model.BillingFormAddress
+import com.checkout.frames.screen.paymentform.model.PaymentFormConfig
+import com.checkout.frames.screen.paymentform.model.PrefillData
+import com.checkout.frames.style.screen.PaymentFormStyle
+import com.checkout.tokenization.model.Address
+import com.checkout.tokenization.model.Phone
+import com.checkout.tokenization.model.TokenDetails
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import org.junit.Rule
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+internal class PaymentFormScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val expectedMockContext: Context = mockk(relaxed = true)
+
+    @Suppress("EmptyFunctionBlock")
+    private val paymentFormConfig = PaymentFormConfig(
+        context = expectedMockContext,
+        environment = Environment.PRODUCTION,
+        publicKey = "Test key",
+        style = PaymentFormStyle(),
+        supportedCardSchemeList = listOf(CardScheme.VISA, CardScheme.MAESTRO),
+        paymentFlowHandler = object : PaymentFlowHandler {
+            override fun onSubmit() {}
+            override fun onSuccess(tokenDetails: TokenDetails) {}
+            override fun onFailure(errorMessage: String) {}
+            override fun onBackPressed() {}
+        },
+        prefillData = PrefillData(
+            cardHolderName = "Test Name",
+            billingFormAddress = BillingFormAddress(
+                name = "Test Billing Address name",
+                address = Address(
+                    addressLine1 = "Checkout.com",
+                    addressLine2 = "90 Tottenham Court Road",
+                    city = "London",
+                    state = "London",
+                    zip = "W1T 4TJ",
+                    country = Country.from(iso3166Alpha2 = "GB")
+                ),
+                phone = Phone(
+                    number = "4155552671", country = Country.from(iso3166Alpha2 = "GB")
+                )
+            )
+        )
+    )
+
+    @Test
+    fun paymentFormScreenShouldBeCreatedWithTheCorrectTestNameFilled() {
+        composeTestRule.setContent {
+            MaterialTheme { PaymentFormScreen(paymentFormConfig) }
+        }
+
+        composeTestRule.onNodeWithText("Test Name").assertIsDisplayed()
+    }
+}

--- a/frames/src/main/java/com/checkout/frames/component/addresssummary/AddressSummaryViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/component/addresssummary/AddressSummaryViewModel.kt
@@ -7,6 +7,7 @@ import com.checkout.base.mapper.Mapper
 import com.checkout.frames.di.base.InjectionClient
 import com.checkout.frames.di.base.Injector
 import com.checkout.frames.di.component.AddressSummaryViewModelSubComponent
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress.Companion.isEdited
 import com.checkout.frames.screen.manager.PaymentStateManager
 import com.checkout.frames.style.component.addresssummary.AddressSummaryComponentStyle
 import com.checkout.frames.style.view.addresssummary.AddressSummaryComponentViewStyle
@@ -16,7 +17,7 @@ import javax.inject.Inject
 import javax.inject.Provider
 
 internal class AddressSummaryViewModel @Inject constructor(
-    private val style: AddressSummaryComponentStyle,
+    style: AddressSummaryComponentStyle,
     private val paymentStateManager: PaymentStateManager,
     private val componentStateMapper: Mapper<AddressSummaryComponentStyle, AddressSummaryComponentState>,
     private val componentStyleMapper: Mapper<AddressSummaryComponentStyle, AddressSummaryComponentViewStyle>
@@ -28,7 +29,11 @@ internal class AddressSummaryViewModel @Inject constructor(
     fun prepare() = viewModelScope.launch {
         paymentStateManager.billingAddress.collect { billingAddress ->
             componentState.addressPreviewState.text.value =
-                if (paymentStateManager.isBillingAddressValid.value) billingAddress.summary() else ""
+                if (paymentStateManager.billingAddress.value.isEdited() &&
+                    paymentStateManager.isBillingAddressEnabled.value
+                )
+                    billingAddress.summary()
+                else ""
         }
     }
 

--- a/frames/src/main/java/com/checkout/frames/di/module/PaymentModule.kt
+++ b/frames/src/main/java/com/checkout/frames/di/module/PaymentModule.kt
@@ -11,6 +11,7 @@ import com.checkout.frames.di.component.CountryViewModelSubComponent
 import com.checkout.frames.di.component.CvvViewModelSubComponent
 import com.checkout.frames.di.component.ExpiryDateViewModelSubComponent
 import com.checkout.frames.di.screen.PaymentDetailsViewModelSubComponent
+import com.checkout.frames.mapper.BillingFormAddressToBillingAddressMapper
 import com.checkout.frames.screen.manager.PaymentFormStateManager
 import com.checkout.frames.screen.manager.PaymentStateManager
 import com.checkout.frames.screen.paymentform.model.PrefillData
@@ -32,6 +33,7 @@ import javax.inject.Singleton
         AddressSummaryViewModelSubComponent::class
     ]
 )
+
 internal class PaymentModule {
     companion object {
         @Provides
@@ -40,6 +42,6 @@ internal class PaymentModule {
             supportedCardSchemes: List<CardScheme>,
             prefillData: PrefillData?
         ): PaymentStateManager =
-            PaymentFormStateManager(supportedCardSchemes, prefillData)
+            PaymentFormStateManager(supportedCardSchemes, prefillData, BillingFormAddressToBillingAddressMapper())
     }
 }

--- a/frames/src/main/java/com/checkout/frames/mapper/BillingFormAddressToBillingAddressMapper.kt
+++ b/frames/src/main/java/com/checkout/frames/mapper/BillingFormAddressToBillingAddressMapper.kt
@@ -1,0 +1,12 @@
+package com.checkout.frames.mapper
+
+import com.checkout.base.mapper.Mapper
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress
+import com.checkout.frames.screen.paymentform.model.BillingFormAddress
+
+internal class BillingFormAddressToBillingAddressMapper : Mapper<BillingFormAddress?, BillingAddress> {
+
+    override fun map(from: BillingFormAddress?) = BillingAddress(
+        name = from?.name, phone = from?.phone, address = from?.address ?: BillingAddress().address
+    )
+}

--- a/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormViewModel.kt
@@ -1,7 +1,6 @@
 package com.checkout.frames.screen.paymentform
 
 import android.content.Context
-import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.checkout.base.model.CardScheme
@@ -29,7 +28,6 @@ internal class PaymentFormViewModel @Inject internal constructor() : ViewModel()
         @Inject
         lateinit var viewModel: PaymentFormViewModel
 
-        @VisibleForTesting
         lateinit var injector: Injector
 
         @Suppress("UNCHECKED_CAST")

--- a/frames/src/main/java/com/checkout/frames/utils/extensions/BillingAddressExtensions.kt
+++ b/frames/src/main/java/com/checkout/frames/utils/extensions/BillingAddressExtensions.kt
@@ -4,7 +4,7 @@ import com.checkout.base.model.Country
 import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress
 import java.util.Locale
 
-internal fun BillingAddress.summary(): String = if (this.isValid()) {
+internal fun BillingAddress.summary(): String {
     val strBuilder = StringBuilder()
 
     // Full name
@@ -22,10 +22,10 @@ internal fun BillingAddress.summary(): String = if (this.isValid()) {
     if (this.phone?.number?.isNotEmpty() == true)
         strBuilder.append("\n+${this.phone.country.dialingCode} ${this.phone.number}")
 
-    strBuilder.toString().trim()
-} else ""
+    return strBuilder.toString().trim()
+}
 
-private fun BillingAddress.isValid(): Boolean = when {
+internal fun BillingAddress.isValid(): Boolean = when {
     this.address == null -> false
     this.address.country == Country.INVALID_COUNTRY -> false
     this.phone == null -> false

--- a/frames/src/test/java/com/checkout/frames/component/cardholdername/CardHolderNameViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/component/cardholdername/CardHolderNameViewModelTest.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import com.checkout.base.mapper.Mapper
 import com.checkout.frames.R
 import com.checkout.frames.component.base.InputComponentState
+import com.checkout.frames.mapper.BillingFormAddressToBillingAddressMapper
 import com.checkout.frames.mapper.ContainerStyleToModifierMapper
 import com.checkout.frames.mapper.TextLabelStyleToViewStyleMapper
 import com.checkout.frames.mapper.ImageStyleToComposableImageMapper
@@ -192,7 +193,10 @@ internal class CardHolderNameViewModelTest {
     }
 
     private fun initPaymentStateManager() {
-        spyPaymentStateManager = PaymentFormStateManager(supportedCardSchemes = emptyList())
+        spyPaymentStateManager = PaymentFormStateManager(
+            supportedCardSchemes = emptyList(),
+            billingFormAddressToBillingAddressMapper = BillingFormAddressToBillingAddressMapper()
+        )
     }
 
     private fun initViewModel() {

--- a/frames/src/test/java/com/checkout/frames/component/cardnumber/CardNumberViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/component/cardnumber/CardNumberViewModelTest.kt
@@ -7,6 +7,7 @@ import com.checkout.base.mapper.Mapper
 import com.checkout.base.model.CardScheme
 import com.checkout.frames.R
 import com.checkout.frames.component.base.InputComponentState
+import com.checkout.frames.mapper.BillingFormAddressToBillingAddressMapper
 import com.checkout.frames.mapper.ImageStyleToDynamicComposableImageMapper
 import com.checkout.frames.mapper.ContainerStyleToModifierMapper
 import com.checkout.frames.mapper.TextLabelStyleToViewStyleMapper
@@ -57,7 +58,10 @@ internal class CardNumberViewModelTest {
     lateinit var spyDynamicImageMapper: ImageStyleToDynamicComposableImageMapper
 
     @SpyK
-    var spyPaymentStateManager: PaymentStateManager = PaymentFormStateManager(supportedCardSchemes = emptyList())
+    var spyPaymentStateManager: PaymentStateManager = PaymentFormStateManager(
+        supportedCardSchemes = emptyList(),
+        billingFormAddressToBillingAddressMapper = BillingFormAddressToBillingAddressMapper()
+    )
 
     private var style: CardNumberComponentStyle = CardNumberComponentStyle()
 

--- a/frames/src/test/java/com/checkout/frames/component/cardscheme/CardSchemeViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/component/cardscheme/CardSchemeViewModelTest.kt
@@ -2,6 +2,7 @@ package com.checkout.frames.component.cardscheme
 
 import android.annotation.SuppressLint
 import com.checkout.base.mapper.Mapper
+import com.checkout.frames.mapper.BillingFormAddressToBillingAddressMapper
 import com.checkout.frames.mapper.ImageStyleToComposableImageMapper
 import com.checkout.frames.mapper.ContainerStyleToModifierMapper
 import com.checkout.frames.mapper.TextLabelStyleToViewStyleMapper
@@ -36,7 +37,10 @@ internal class CardSchemeViewModelTest {
     lateinit var spyImageStyleToComposableImageMapper: ImageStyleToComposableImageMapper
 
     @SpyK
-    var spyPaymentStateManager: PaymentStateManager = PaymentFormStateManager(supportedCardSchemes = emptyList())
+    var spyPaymentStateManager: PaymentStateManager = PaymentFormStateManager(
+        supportedCardSchemes = emptyList(),
+        billingFormAddressToBillingAddressMapper = BillingFormAddressToBillingAddressMapper()
+    )
 
     private var style: CardSchemeComponentStyle = CardSchemeComponentStyle()
 

--- a/frames/src/test/java/com/checkout/frames/component/country/CountryViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/component/country/CountryViewModelTest.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import com.checkout.base.mapper.Mapper
 import com.checkout.base.model.Country
 import com.checkout.frames.component.base.InputComponentState
+import com.checkout.frames.mapper.BillingFormAddressToBillingAddressMapper
 import com.checkout.frames.mapper.ContainerStyleToModifierMapper
 import com.checkout.frames.mapper.ImageStyleToComposableImageMapper
 import com.checkout.frames.mapper.InputComponentStyleToStateMapper
@@ -46,7 +47,10 @@ internal class CountryViewModelTest {
     lateinit var spyInputComponentStateMapper: Mapper<InputComponentStyle, InputComponentState>
 
     @SpyK
-    var spyPaymentStateManager: PaymentStateManager = PaymentFormStateManager(supportedCardSchemes = emptyList())
+    var spyPaymentStateManager: PaymentStateManager = PaymentFormStateManager(
+        supportedCardSchemes = emptyList(),
+        billingFormAddressToBillingAddressMapper = BillingFormAddressToBillingAddressMapper()
+    )
 
     private lateinit var viewModel: CountryViewModel
     private var style = CountryComponentStyle()

--- a/frames/src/test/java/com/checkout/frames/component/cvv/CvvViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/component/cvv/CvvViewModelTest.kt
@@ -7,6 +7,7 @@ import com.checkout.base.mapper.Mapper
 import com.checkout.base.model.CardScheme
 import com.checkout.frames.R
 import com.checkout.frames.component.base.InputComponentState
+import com.checkout.frames.mapper.BillingFormAddressToBillingAddressMapper
 import com.checkout.frames.mapper.ContainerStyleToModifierMapper
 import com.checkout.frames.mapper.TextLabelStyleToViewStyleMapper
 import com.checkout.frames.mapper.ImageStyleToComposableImageMapper
@@ -62,7 +63,10 @@ internal class CvvViewModelTest {
     lateinit var spyInputComponentStateMapper: Mapper<InputComponentStyle, InputComponentState>
 
     @SpyK
-    var spyPaymentStateManager: PaymentStateManager = PaymentFormStateManager(supportedCardSchemes = emptyList())
+    var spyPaymentStateManager: PaymentStateManager = PaymentFormStateManager(
+        supportedCardSchemes = emptyList(),
+        billingFormAddressToBillingAddressMapper = BillingFormAddressToBillingAddressMapper()
+    )
 
     private var style: CvvComponentStyle = CvvComponentStyle()
 

--- a/frames/src/test/java/com/checkout/frames/component/expirydate/ExpiryDateViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/component/expirydate/ExpiryDateViewModelTest.kt
@@ -8,6 +8,7 @@ import com.checkout.frames.R
 import com.checkout.frames.component.base.InputComponentState
 import com.checkout.frames.component.expirydate.model.SmartExpiryDateValidationRequest
 import com.checkout.frames.component.expirydate.usecase.SmartExpiryDateValidationUseCase
+import com.checkout.frames.mapper.BillingFormAddressToBillingAddressMapper
 import com.checkout.frames.mapper.ContainerStyleToModifierMapper
 import com.checkout.frames.mapper.TextLabelStyleToViewStyleMapper
 import com.checkout.frames.mapper.ImageStyleToComposableImageMapper
@@ -53,7 +54,10 @@ internal class ExpiryDateViewModelTest {
     lateinit var spyInputComponentStateMapper: Mapper<InputComponentStyle, InputComponentState>
 
     @SpyK
-    var spyPaymentStateManager: PaymentStateManager = PaymentFormStateManager(supportedCardSchemes = emptyList())
+    var spyPaymentStateManager: PaymentStateManager = PaymentFormStateManager(
+        supportedCardSchemes = emptyList(),
+        billingFormAddressToBillingAddressMapper = BillingFormAddressToBillingAddressMapper()
+    )
 
     private var style: ExpiryDateComponentStyle = ExpiryDateComponentStyle(InputComponentStyle())
 

--- a/frames/src/test/java/com/checkout/frames/component/paybutton/PayButtonViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/component/paybutton/PayButtonViewModelTest.kt
@@ -5,6 +5,7 @@ import com.checkout.base.mapper.Mapper
 import com.checkout.base.model.Country
 import com.checkout.base.usecase.UseCase
 import com.checkout.frames.logging.PaymentFormEventType
+import com.checkout.frames.mapper.BillingFormAddressToBillingAddressMapper
 import com.checkout.frames.mapper.ButtonStyleToInternalStateMapper
 import com.checkout.frames.mapper.ButtonStyleToInternalViewStyleMapper
 import com.checkout.frames.mapper.ContainerStyleToModifierMapper
@@ -62,7 +63,10 @@ internal class PayButtonViewModelTest {
     private lateinit var spyButtonStateMapper: Mapper<ButtonStyle, InternalButtonState>
 
     @SpyK
-    var spyPaymentStateManager: PaymentStateManager = PaymentFormStateManager(supportedCardSchemes = emptyList())
+    var spyPaymentStateManager: PaymentStateManager = PaymentFormStateManager(
+        supportedCardSchemes = emptyList(),
+        billingFormAddressToBillingAddressMapper = BillingFormAddressToBillingAddressMapper()
+    )
 
     private val dispatcher = StandardTestDispatcher()
     private val capturedEvent = slot<LoggingEvent>()

--- a/frames/src/test/java/com/checkout/frames/countrypicker/CountryPickerViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/countrypicker/CountryPickerViewModelTest.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import androidx.compose.ui.Modifier
 import com.checkout.base.mapper.Mapper
 import com.checkout.base.model.Country
+import com.checkout.frames.mapper.BillingFormAddressToBillingAddressMapper
 import com.checkout.frames.mapper.ImageStyleToComposableImageMapper
 import com.checkout.frames.mapper.ContainerStyleToModifierMapper
 import com.checkout.frames.mapper.TextLabelStyleToViewStyleMapper
@@ -29,7 +30,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertFalse
-
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -58,7 +58,10 @@ internal class CountryPickerViewModelTest {
     lateinit var spyDynamicImageMapper: ImageStyleToDynamicComposableImageMapper
 
     @SpyK
-    var paymentStateManager: PaymentStateManager = PaymentFormStateManager(supportedCardSchemes = emptyList())
+    var paymentStateManager: PaymentStateManager = PaymentFormStateManager(
+        supportedCardSchemes = emptyList(),
+        billingFormAddressToBillingAddressMapper = BillingFormAddressToBillingAddressMapper()
+    )
 
     private val style: CountryPickerStyle = CountryPickerStyle()
     private lateinit var viewModel: CountryPickerViewModel

--- a/frames/src/test/java/com/checkout/frames/mapper/BillingFormAddressToBillingAddressMapperTest.kt
+++ b/frames/src/test/java/com/checkout/frames/mapper/BillingFormAddressToBillingAddressMapperTest.kt
@@ -1,0 +1,105 @@
+package com.checkout.frames.mapper
+
+import android.annotation.SuppressLint
+import com.checkout.base.mapper.Mapper
+import com.checkout.base.model.Country
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress
+import com.checkout.frames.screen.paymentform.model.BillingFormAddress
+import com.checkout.tokenization.model.Address
+import com.checkout.tokenization.model.Phone
+import io.mockk.junit5.MockKExtension
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+@SuppressLint("NewApi")
+@ExtendWith(MockKExtension::class)
+internal class BillingFormAddressToBillingAddressMapperTest {
+    private lateinit var billingFormAddressToBillingAddressMapper: Mapper<BillingFormAddress?, BillingAddress>
+
+    @BeforeEach
+    fun setUp() {
+        billingFormAddressToBillingAddressMapper = BillingFormAddressToBillingAddressMapper()
+    }
+
+    @ParameterizedTest(
+        name = "When summary of billing address {0} is requested then addressPreview {1} is provided"
+    )
+    @MethodSource("testBillingAddressSummaryArguments")
+    fun `mapping of BillingFormAddress to BillingAddress data should return correct data`(
+        billingFormAddress: BillingFormAddress,
+        expectedBillingAddress: BillingAddress,
+    ) {
+        // When
+        val actualBillingAddress = billingFormAddressToBillingAddressMapper.map(billingFormAddress)
+
+        // Then
+        assertEquals(expectedBillingAddress, actualBillingAddress)
+    }
+
+    companion object {
+        @JvmStatic
+        fun testBillingAddressSummaryArguments(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                BillingFormAddress(
+                    address = Address(
+                        addressLine1 = "LINE 1",
+                        addressLine2 = "LINE 2",
+                        city = "city",
+                        state = "state",
+                        zip = "zipcode",
+                        country = Country.UNITED_KINGDOM
+                    ),
+                    phone = Phone("123", Country.UNITED_KINGDOM)
+                ),
+                BillingAddress(
+                    address = Address(
+                        addressLine1 = "LINE 1",
+                        addressLine2 = "LINE 2",
+                        city = "city",
+                        state = "state",
+                        zip = "zipcode",
+                        country = Country.UNITED_KINGDOM
+                    ),
+                    phone = Phone("123", Country.UNITED_KINGDOM)
+                ),
+                BillingFormAddress(
+                    name = "Test name", phone = Phone("123", Country.UNITED_KINGDOM)
+                ),
+                BillingAddress(
+                    name = "Test name", phone = Phone("123", Country.UNITED_KINGDOM)
+                ),
+                BillingFormAddress(name = "Test name"), BillingAddress(name = "Test name"),
+                BillingFormAddress(
+                    name = "Test name",
+                    address = Address(
+                        addressLine1 = "",
+                        addressLine2 = "",
+                        city = "",
+                        state = "state",
+                        zip = "zipcode",
+                        country = Country.UNITED_KINGDOM
+                    )
+                ),
+                BillingAddress(
+                    name = "Test name",
+                    address = Address(
+                        addressLine1 = "",
+                        addressLine2 = "",
+                        city = "",
+                        state = "state",
+                        zip = "zipcode",
+                        country = Country.UNITED_KINGDOM
+                    )
+                ),
+                BillingFormAddress(), BillingAddress(),
+                BillingFormAddress(name = "Test name", address = null),
+                BillingAddress(name = "Test name", address = BillingAddress().address)
+            )
+        )
+    }
+}

--- a/frames/src/test/java/com/checkout/frames/mock/PaymentFormConfigTestData.kt
+++ b/frames/src/test/java/com/checkout/frames/mock/PaymentFormConfigTestData.kt
@@ -13,7 +13,8 @@ import com.checkout.tokenization.model.TokenDetails
 internal object PaymentFormConfigTestData {
 
     private val country = Country.from(iso3166Alpha2 = "GB")
-    private val address = Address(
+
+    val address = Address(
         addressLine1 = "Checkout.com",
         addressLine2 = "90 Tottenham Court Road",
         city = "London",
@@ -21,7 +22,8 @@ internal object PaymentFormConfigTestData {
         zip = "W1T 4TJ",
         country = country
     )
-    private val phone = Phone("4155552671", country)
+
+    val phone = Phone("4155552671", country)
     private val billingFormAddress = BillingFormAddress(
         name = "Test Billing Address name", address = address, phone = phone
     )

--- a/frames/src/test/java/com/checkout/frames/screen/billingaddressdetails/BillingAddressDetailsViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/billingaddressdetails/BillingAddressDetailsViewModelTest.kt
@@ -10,6 +10,7 @@ import com.checkout.frames.component.base.InputComponentState
 import com.checkout.frames.component.billingaddressfields.BillingAddressInputComponentState
 import com.checkout.frames.component.billingaddressfields.BillingAddressInputComponentsContainerState
 import com.checkout.frames.logging.BillingFormEventType
+import com.checkout.frames.mapper.BillingFormAddressToBillingAddressMapper
 import com.checkout.frames.mapper.ButtonStyleToInternalStateMapper
 import com.checkout.frames.mapper.ButtonStyleToInternalViewStyleMapper
 import com.checkout.frames.mapper.ContainerStyleToModifierMapper
@@ -75,7 +76,10 @@ internal class BillingAddressDetailsViewModelTest {
     lateinit var mockLogger: Logger<LoggingEvent>
 
     @SpyK
-    var spyPaymentStateManager: PaymentStateManager = PaymentFormStateManager(supportedCardSchemes = emptyList())
+    var spyPaymentStateManager: PaymentStateManager = PaymentFormStateManager(
+        supportedCardSchemes = emptyList(),
+        billingFormAddressToBillingAddressMapper = BillingFormAddressToBillingAddressMapper()
+    )
 
     @SpyK
     lateinit var spyTextLabelStyleMapper: Mapper<TextLabelStyle, TextLabelViewStyle>

--- a/frames/src/test/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModelTest.kt
@@ -13,6 +13,9 @@ import com.checkout.frames.mapper.TextLabelStyleToViewStyleMapper
 import com.checkout.frames.mapper.TextLabelStyleToStateMapper
 import com.checkout.frames.mapper.ImageStyleToComposableImageMapper
 import com.checkout.frames.mapper.ContainerStyleToModifierMapper
+import com.checkout.frames.mock.PaymentFormConfigTestData
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress.Companion.isEdited
 import com.checkout.frames.screen.manager.PaymentStateManager
 import com.checkout.frames.style.component.base.ContainerStyle
 import com.checkout.frames.style.component.base.TextLabelStyle
@@ -20,6 +23,7 @@ import com.checkout.frames.style.component.default.DefaultCardHolderNameComponen
 import com.checkout.frames.style.component.default.DefaultLightStyle
 import com.checkout.frames.style.screen.PaymentDetailsStyle
 import com.checkout.frames.style.view.TextLabelViewStyle
+import com.checkout.frames.utils.extensions.isValid
 import com.checkout.frames.view.TextLabelState
 import com.checkout.logging.Logger
 import com.checkout.logging.model.LoggingEvent
@@ -81,6 +85,7 @@ internal class PaymentDetailsViewModelTest {
     fun setUp() {
         every { mockLogger.log(capture(capturedEvent)) } returns Unit
         every { mockClosePaymentFlowUseCase.execute(Unit) } returns Unit
+        every { mockPaymentStateManager.billingAddress.value } returns BillingAddress()
 
         initViewModel(style)
     }
@@ -133,6 +138,28 @@ internal class PaymentDetailsViewModelTest {
         // Then
         verify(exactly = 1) { mockClosePaymentFlowUseCase.execute(Unit) }
         assertEquals(PaymentFormEventType.CANCELED.eventId, capturedEvent.captured.typeIdentifier)
+    }
+
+    @Test
+    fun `when view model is initialised then provideIsBillingAddressValid function should provide correct values`() {
+        // Given
+        val expectedIsBillingAddressEdited = true
+        val expectedIsBillingAddressValid = true
+        val expectedIsBillingAddressValidByDefault = true
+        every { mockPaymentStateManager.billingAddress.value } returns BillingAddress(
+            address = PaymentFormConfigTestData.address,
+            name = "Test name",
+            phone = PaymentFormConfigTestData.phone
+        )
+
+        // When
+        initViewModel(style)
+
+        // Then
+        assertEquals(expectedIsBillingAddressEdited, mockPaymentStateManager.billingAddress.value.isEdited())
+        assertEquals(expectedIsBillingAddressValid, mockPaymentStateManager.billingAddress.value.isValid())
+        assertEquals(true, style.addressSummaryStyle != null)
+        assertEquals(expectedIsBillingAddressValidByDefault, viewModel.provideIsBillingAddressValid())
     }
 
     @ParameterizedTest(

--- a/frames/src/test/java/com/checkout/frames/utils/extensions/BillingAddressExtensionsTest.kt
+++ b/frames/src/test/java/com/checkout/frames/utils/extensions/BillingAddressExtensionsTest.kt
@@ -1,0 +1,141 @@
+package com.checkout.frames.utils.extensions
+
+import android.annotation.SuppressLint
+import com.checkout.base.model.Country
+import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress
+import com.checkout.tokenization.model.Address
+import com.checkout.tokenization.model.Phone
+import io.mockk.junit5.MockKExtension
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+@SuppressLint("NewApi")
+@ExtendWith(MockKExtension::class)
+internal class BillingAddressExtensionsTest {
+
+    @ParameterizedTest(
+        name = "When summary of billing address {0} is requested then addressPreview {1} is provided"
+    )
+    @MethodSource("testBillingAddressSummaryArguments")
+    fun `Requested billing address summary should provide correct address preview text`(
+        billingAddress: BillingAddress,
+        expectedAddressPreview: String,
+    ) {
+        // When
+        val result = billingAddress.summary()
+
+        // Then
+        assertEquals(expectedAddressPreview, result)
+    }
+
+    @ParameterizedTest(
+        name = "When summary of billing address {0} is requested then addressPreview {1} is provided"
+    )
+    @MethodSource("testIsBillingAddressValidArguments")
+    fun `Requested to verify valid billing address should provide correct validation`(
+        billingAddress: BillingAddress,
+        expectedIsBillingAddressValid: Boolean,
+    ) {
+        // When
+        val result = billingAddress.isValid()
+
+        // Then
+        assertEquals(expectedIsBillingAddressValid, result)
+    }
+
+    companion object {
+        @JvmStatic
+        fun testBillingAddressSummaryArguments(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                BillingAddress(
+                    address = Address(
+                        addressLine1 = "LINE 1",
+                        addressLine2 = "LINE 2",
+                        city = "city",
+                        state = "state",
+                        zip = "zipcode",
+                        country = Country.UNITED_KINGDOM
+                    ),
+                    phone = Phone("123", Country.UNITED_KINGDOM)
+                ),
+                "LINE 1\nLINE 2\ncity\nstate\nzipcode\nUnited Kingdom\n+44 123",
+                BillingAddress(
+                    name = "Test name",
+                    phone = Phone("123", Country.UNITED_KINGDOM)
+                ),
+                "Test name\n+44 123",
+                BillingAddress(
+                    name = "Test name"
+                ),
+                "Test name",
+                BillingAddress(
+                    name = "Test name",
+                    address = Address(
+                        addressLine1 = "",
+                        addressLine2 = "",
+                        city = "",
+                        state = "state",
+                        zip = "zipcode",
+                        country = Country.UNITED_KINGDOM
+                    )
+                ),
+                "Test name\nstate\nzipcode\nUnited Kingdom",
+                BillingAddress(), ""
+            )
+        )
+
+        @JvmStatic
+        fun testIsBillingAddressValidArguments(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                BillingAddress(
+                    address = Address(
+                        addressLine1 = "LINE 1",
+                        addressLine2 = "LINE 2",
+                        city = "city",
+                        state = "state",
+                        zip = "zipcode",
+                        country = Country.UNITED_KINGDOM
+                    ),
+                    phone = Phone("123", Country.UNITED_KINGDOM)
+                ),
+                true,
+                BillingAddress(
+                    name = "Test name", phone = Phone("123", Country.UNITED_KINGDOM)
+                ),
+                false,
+                BillingAddress(
+                    name = "Test name"
+                ),
+                false,
+                BillingAddress(
+                    name = "Test name",
+                    address = Address(
+                        addressLine1 = "",
+                        addressLine2 = "",
+                        city = "",
+                        state = "state",
+                        zip = "zipcode",
+                        country = Country.INVALID_COUNTRY
+                    )
+                ),
+                false,
+                BillingAddress(
+                    name = "Test name",
+                    address = Address(
+                        addressLine1 = "",
+                        addressLine2 = "",
+                        city = "",
+                        state = "state",
+                        zip = "zipcode",
+                        country = Country.UNITED_KINGDOM
+                    )
+                ),
+                false
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Issue

[PIMOB-2093](https://checkout.atlassian.net/browse/PIMOB-2093)

## Proposed changes
1. added capabilities of billing form address in prefilldata from payment form config
2. Added unit tests for it

## Test Steps

_If there's any functionality change, please list a step by step guide of how to verify the changes, and/or upload a screen recording for any visible changes._ 

1. Add billing form address in prefill data from payment form config. Refer main activity from sample app
2. verify address summary should update. (attached video)
3. Click on edit address summary and change the fields from the billing form, then Address summary should updated accordingly

## Checklist
[billling_recording_20230821_094805.webm](https://github.com/checkout/frames-android/assets/114917119/940681fe-0222-4933-83df-fd22c8b31453)

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Reviewers assigned
* [X] I have performed a self-review of my code and manual testing
* [X] Lint and unit tests pass locally with my changes
* [X] I have added tests that prove my fix is effective or that my feature works
* [X] I have added necessary documentation (if applicable)

## Further comments

_If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered, etc..._


[PIMOB-2093]: https://checkout.atlassian.net/browse/PIMOB-2093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ