### PR TITLE
PIMOB: 2133 -mapping of country in phone object from token response improved

### DIFF
--- a/checkout/src/main/java/com/checkout/base/model/Country.kt
+++ b/checkout/src/main/java/com/checkout/base/model/Country.kt
@@ -270,9 +270,10 @@ public enum class Country(
             return country ?: INVALID_COUNTRY
         }
 
-        internal fun getCountryFromDialingCode(dialingCode: String): Country {
-            val country: Country? = values().firstOrNull {
-                it.dialingCode.equals(dialingCode, true)
+        internal fun getCountry(dialingCode: String, iso3166Alpha2: String?): Country {
+            val country: Country? = values().firstOrNull { country ->
+                country.dialingCode.equals(dialingCode, true) &&
+                        country.iso3166Alpha2.equals(iso3166Alpha2, true)
             }
 
             return country ?: INVALID_COUNTRY

--- a/checkout/src/main/java/com/checkout/tokenization/mapper/response/CardTokenizationNetworkDataMapper.kt
+++ b/checkout/src/main/java/com/checkout/tokenization/mapper/response/CardTokenizationNetworkDataMapper.kt
@@ -38,7 +38,7 @@ internal class CardTokenizationNetworkDataMapper : TokenizationNetworkDataMapper
             productId = result.productId,
             productType = result.productType,
             billingAddress = result.billingAddress?.let { AddressEntityToAddressDataMapper().map(it) },
-            phone = result.phone?.let { PhoneEntityToPhoneDataMapper().map(it) },
+            phone = result.phone?.let { PhoneEntityToPhoneDataMapper(result.billingAddress?.country).map(it) },
             name = result.name
         )
 }

--- a/checkout/src/main/java/com/checkout/tokenization/mapper/response/PhoneEntityToPhoneDataMapper.kt
+++ b/checkout/src/main/java/com/checkout/tokenization/mapper/response/PhoneEntityToPhoneDataMapper.kt
@@ -8,10 +8,10 @@ import com.checkout.tokenization.entity.PhoneEntity
 /**
  * Mapping of [PhoneEntity] to [Phone]
  */
-internal class PhoneEntityToPhoneDataMapper : Mapper<PhoneEntity, Phone> {
+internal class PhoneEntityToPhoneDataMapper(private val iso3166Alpha2: String? = null) : Mapper<PhoneEntity, Phone> {
 
     override fun map(from: PhoneEntity): Phone = Phone(
         from.number,
-        Country.getCountryFromDialingCode(from.countryCode),
+        Country.getCountry(from.countryCode, iso3166Alpha2)
     )
 }

--- a/checkout/src/test/java/com/checkout/base/model/CountryTest.kt
+++ b/checkout/src/test/java/com/checkout/base/model/CountryTest.kt
@@ -30,6 +30,30 @@ internal class CountryTest {
     }
 
     @Test
+    fun `given full country details should returns valid country`() {
+        // Given
+        val expectedCountry = Country.UNITED_KINGDOM
+
+        // When
+        val actualCountry = Country.getCountry("44", "GB")
+
+        // Then
+        assertEquals(expectedCountry, actualCountry)
+    }
+
+    @Test
+    fun `given country details should returns invalid country`() {
+        // Given
+        val expectedCountry = Country.INVALID_COUNTRY
+
+        // When
+        val actualCountry = Country.getCountry("44", null)
+
+        // Then
+        assertEquals(expectedCountry, actualCountry)
+    }
+
+    @Test
     fun `given invalid country Iso3166Alpha2 code returns Invalid country`() {
         // Given
         val expectedCountry = Country.INVALID_COUNTRY

--- a/checkout/src/test/java/com/checkout/tokenization/mapper/CardTokenizationNetworkDataMapperTest.kt
+++ b/checkout/src/test/java/com/checkout/tokenization/mapper/CardTokenizationNetworkDataMapperTest.kt
@@ -93,7 +93,8 @@ internal class CardTokenizationNetworkDataMapperTest {
                 productId = "F",
                 productType = "CLASSIC",
                 billingAddress = AddressEntityToAddressDataMapper().map(CardTokenTestData.addressEntity),
-                phone = PhoneEntityToPhoneDataMapper().map(CardTokenTestData.phoneEntity),
+                phone = PhoneEntityToPhoneDataMapper(CardTokenTestData.addressEntity.country)
+                    .map(CardTokenTestData.phoneEntity),
                 name = "Bruce Wayne"
             )
 

--- a/checkout/src/test/java/com/checkout/tokenization/mapper/response/PhoneEntityToPhoneDataMapperTest.kt
+++ b/checkout/src/test/java/com/checkout/tokenization/mapper/response/PhoneEntityToPhoneDataMapperTest.kt
@@ -12,13 +12,19 @@ internal class PhoneEntityToPhoneDataMapperTest {
 
     @BeforeEach
     fun setUp() {
-        phoneEntityToPhoneDataMapper = PhoneEntityToPhoneDataMapper()
+        phoneEntityToPhoneDataMapper = PhoneEntityToPhoneDataMapper("GB")
     }
 
     @Test
     fun `mapping of PhoneEntity to Phone data`() {
         // Given
-        val expectedPhoneData = Phone("4155552671", Country.getCountryFromDialingCode("44"))
+        val expectedPhoneData = Phone(
+            number = "4155552671",
+            country = Country.getCountry(
+                dialingCode = "44",
+                iso3166Alpha2 = "GB"
+            )
+        )
 
         // When
         val actualPhoneData = phoneEntityToPhoneDataMapper.map(CardTokenTestData.phoneEntity)


### PR DESCRIPTION
## Issue

[PIMOB-2113](https://checkout.atlassian.net/browse/PIMOB-2113)

## Proposed changes
1 Receiving on token response, the country object from the phone should be correct as sent in the token request.
2 updated unit tests

## Test Steps
Steps to reproduce the issue:
1 fill payment form along with billing address details. Choose a country as the united kingdom
2 Hit the pay button and verify the token response. It contains an invalid country object from the phone in the Token response from the SDK. See attached video for reference. 

Expected:
Receiving on token response, country object from the phone should be correct as sent in the token request.
[Uploading billling_recording_20230821_094805.webm…]()

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Reviewers assigned
* [X] I have performed a self-review of my code and manual testing
* [X] Lint and unit tests pass locally with my changes
* [X] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)

## Further comments

_If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered, etc..._


[PIMOB-2113]: https://checkout.atlassian.net/browse/PIMOB-2113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ