### PR TITLE
PIMOB:2119 - Country prefilled without saving from billing form was fixed

### DIFF
--- a/frames/src/main/java/com/checkout/frames/component/country/CountryViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/component/country/CountryViewModel.kt
@@ -32,8 +32,8 @@ internal class CountryViewModel @Inject constructor(
 
     fun prepare(onCountryUpdated: (country: Country?) -> Unit) {
         viewModelScope.launch {
-            paymentStateManager.billingAddress.collect { billingAddress ->
-                billingAddress.address?.country?.let { country ->
+            paymentStateManager.selectedCountry.collect { selectedCountry ->
+                selectedCountry?.let { country ->
                     val name = country.iso3166Alpha2.let {
                         Locale(Locale.getDefault().language, it).displayCountry
                     }

--- a/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/BillingAddressDetailsViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/billingaddress/billingaddressdetails/BillingAddressDetailsViewModel.kt
@@ -208,8 +208,10 @@ internal class BillingAddressDetailsViewModel @Inject constructor(
     }
 
     private fun updateBillingAddress() {
-        val country = paymentStateManager.billingAddress.value.address?.country
-        paymentStateManager.billingAddress.value = inputComponentsStateList.provideBillingAddressDetails(country)
+        val selectedCountry = paymentStateManager.selectedCountry.value
+        paymentStateManager.billingAddress.value.address?.country = selectedCountry
+        paymentStateManager.billingAddress.value =
+            inputComponentsStateList.provideBillingAddressDetails(selectedCountry)
         paymentStateManager.isBillingAddressValid.value = true
     }
 

--- a/frames/src/main/java/com/checkout/frames/screen/countrypicker/CountryPickerViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/countrypicker/CountryPickerViewModel.kt
@@ -69,7 +69,7 @@ internal class CountryPickerViewModel @Inject constructor(
     }
 
     fun onCountryChosen(iso2: String) {
-        paymentStateManager.billingAddress.value.address?.country = Country.from(iso2)
+        paymentStateManager.selectedCountry.value = Country.from(iso2)
         onLeaveScreen()
     }
 

--- a/frames/src/main/java/com/checkout/frames/screen/manager/PaymentFormStateManager.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/manager/PaymentFormStateManager.kt
@@ -3,6 +3,7 @@ package com.checkout.frames.screen.manager
 import androidx.annotation.VisibleForTesting
 import com.checkout.base.mapper.Mapper
 import com.checkout.base.model.CardScheme
+import com.checkout.base.model.Country
 import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress
 import com.checkout.frames.screen.paymentform.model.BillingFormAddress
 import com.checkout.frames.screen.paymentform.model.PrefillData
@@ -35,6 +36,10 @@ internal class PaymentFormStateManager(
 
     override val billingAddress: MutableStateFlow<BillingAddress> = MutableStateFlow(provideBillingFormAddress())
 
+    override val selectedCountry: MutableStateFlow<Country?> = MutableStateFlow(
+        paymentFormPrefillData?.billingFormAddress?.address?.country
+    )
+
     override val isBillingAddressValid: MutableStateFlow<Boolean> = MutableStateFlow(false)
     override val isBillingAddressEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
     override val visitedCountryPicker: MutableStateFlow<Boolean> = MutableStateFlow(false)
@@ -61,6 +66,7 @@ internal class PaymentFormStateManager(
         visitedCountryPicker.value = false
         this.isBillingAddressValid.value = isBillingAddressValid
         this.isBillingAddressEnabled.value = isBillingAddressEnabled
+        this.selectedCountry.value = null
     }
 
     @VisibleForTesting

--- a/frames/src/main/java/com/checkout/frames/screen/manager/PaymentStateManager.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/manager/PaymentStateManager.kt
@@ -1,6 +1,7 @@
 package com.checkout.frames.screen.manager
 
 import com.checkout.base.model.CardScheme
+import com.checkout.base.model.Country
 import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -27,6 +28,7 @@ internal interface PaymentStateManager {
     val supportedCardSchemeList: List<CardScheme>
 
     val billingAddress: MutableStateFlow<BillingAddress>
+    val selectedCountry: MutableStateFlow<Country?>
     val isBillingAddressValid: MutableStateFlow<Boolean>
     // Whether the billing address form is enabled or set to null
     val isBillingAddressEnabled: MutableStateFlow<Boolean>

--- a/frames/src/main/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsScreen.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsScreen.kt
@@ -8,12 +8,17 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.checkout.frames.di.base.Injector
@@ -34,6 +39,29 @@ internal fun PaymentDetailsScreen(
     val viewModel: PaymentDetailsViewModel = viewModel(
         factory = PaymentDetailsViewModel.Factory(injector, style)
     )
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    // Observe the lifecycle of the Composable
+    val lifecycle = rememberUpdatedState(lifecycleOwner.lifecycle)
+
+    // Create a DefaultLifecycleObserver to handle ON_RESUME
+    val observer = rememberUpdatedState(
+        object : DefaultLifecycleObserver {
+            override fun onResume(owner: LifecycleOwner) {
+                super.onResume(owner)
+               viewModel.resetCountrySelection()
+            }
+        }
+    )
+
+    DisposableEffect(lifecycleOwner) {
+        lifecycle.value.addObserver(observer.value)
+
+        onDispose {
+            lifecycle.value.removeObserver(observer.value)
+        }
+    }
 
     Column(
         modifier = Modifier.clickable(

--- a/frames/src/main/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModel.kt
@@ -99,6 +99,14 @@ internal class PaymentDetailsViewModel @Inject constructor(
         ).apply { leadingIcon.value = clickableImageStyleMapper.map(imageRequest) }
     }
 
+    fun resetCountrySelection() {
+        with(paymentStateManager) {
+            if (selectedCountry.value != billingAddress.value.address?.country) {
+                selectedCountry.value = billingAddress.value.address?.country
+            }
+        }
+    }
+
     internal class Factory(
         private val injector: Injector,
         private val style: PaymentDetailsStyle

--- a/frames/src/test/java/com/checkout/frames/component/country/CountryViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/component/country/CountryViewModelTest.kt
@@ -105,7 +105,7 @@ internal class CountryViewModelTest {
     @Test
     fun `when country field data is updated it should call onCountryUpdated`() = runTest {
         // Given
-        spyPaymentStateManager.billingAddress.value.address?.country = Country.UNITED_KINGDOM
+        spyPaymentStateManager.selectedCountry.value = Country.UNITED_KINGDOM
 
         fun assertUpdatedCountry(expectedCountry: Country, actualCountry: Country?) {
             assertEquals(expectedCountry, actualCountry)
@@ -122,12 +122,10 @@ internal class CountryViewModelTest {
         // Given
         val testCountry = Country.UNITED_STATES_OF_AMERICA
         val expectedCountryFieldText = "\uD83C\uDDFA\uD83C\uDDF8    United States"
-
-        spyPaymentStateManager.billingAddress.value.address?.country = Country.UNITED_KINGDOM
         viewModel.prepare { }
 
         // When
-        spyPaymentStateManager.billingAddress.value.address?.country = testCountry
+        spyPaymentStateManager.selectedCountry.value = testCountry
         testScheduler.advanceUntilIdle()
 
         // Then

--- a/frames/src/test/java/com/checkout/frames/countrypicker/CountryPickerViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/countrypicker/CountryPickerViewModelTest.kt
@@ -185,8 +185,8 @@ internal class CountryPickerViewModelTest {
         viewModel.onCountryChosen("UA")
 
         // Then
-        val actualBillingForm = paymentStateManager.billingAddress.value
-        assertEquals(expectedCountry, actualBillingForm.address?.country)
+        val actualCountry = paymentStateManager.selectedCountry.value
+        assertEquals(expectedCountry, actualCountry)
     }
 
     @Test

--- a/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
+++ b/frames/src/test/java/com/checkout/frames/manager/PaymentFormStateManagerTest.kt
@@ -61,6 +61,21 @@ internal class PaymentFormStateManagerTest {
     }
 
     @Test
+    fun `when country is prefilled then selectedCountry in the payment state manager should updated correctly`() {
+        // Given
+        val givenPrefilledBillingFormAddress = BillingFormAddress(address = PaymentFormConfigTestData.address)
+        paymentFormStateManager = PaymentFormStateManager(
+            emptyList(),
+            paymentFormPrefillData = PrefillData(billingFormAddress = givenPrefilledBillingFormAddress),
+            spyBillingFormAddressToBillingAddressMapper
+        )
+        val expectedCountry = Country.UNITED_KINGDOM
+
+        // Then
+        Assertions.assertEquals(paymentFormStateManager.selectedCountry.value, expectedCountry)
+    }
+
+    @Test
     fun `when custom supported card schemes isn't provided then checkout's all supportedCardSchemes should updated`() {
         // Given
         paymentFormStateManager = PaymentFormStateManager(
@@ -174,6 +189,7 @@ internal class PaymentFormStateManagerTest {
         Assertions.assertEquals(paymentFormStateManager.visitedCountryPicker.value, false)
         Assertions.assertEquals(paymentFormStateManager.supportedCardSchemeList, supportedSchemes)
         Assertions.assertEquals(paymentFormStateManager.cardHolderName.value, cardHolderName)
+        Assertions.assertEquals(paymentFormStateManager.selectedCountry.value, null)
     }
 
     companion object {

--- a/frames/src/test/java/com/checkout/frames/screen/billingaddressdetails/BillingAddressDetailsViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/billingaddressdetails/BillingAddressDetailsViewModelTest.kt
@@ -254,6 +254,10 @@ internal class BillingAddressDetailsViewModelTest {
 
         // Then
         testScheduler.advanceUntilIdle()
+        assertEquals(spyPaymentStateManager.selectedCountry.value, expectedBillingAddress.address?.country)
+        assertEquals(
+            spyPaymentStateManager.selectedCountry.value, spyPaymentStateManager.billingAddress.value.address?.country
+        )
         assertEquals(spyPaymentStateManager.billingAddress.value, expectedBillingAddress)
     }
 

--- a/frames/src/test/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/paymentdetails/PaymentDetailsViewModelTest.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.Modifier
 import com.checkout.base.mapper.Mapper
+import com.checkout.base.model.Country
 import com.checkout.base.usecase.UseCase
 import com.checkout.frames.component.provider.ComponentProvider
 import com.checkout.frames.logging.PaymentFormEventType
@@ -34,6 +35,7 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.amshove.kluent.internal.assertEquals
+import org.amshove.kluent.internal.assertNotEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -137,6 +139,24 @@ internal class PaymentDetailsViewModelTest {
         // Then
         verify(exactly = 1) { mockClosePaymentFlowUseCase.execute(Unit) }
         assertEquals(PaymentFormEventType.CANCELED.eventId, capturedEvent.captured.typeIdentifier)
+    }
+
+    @Test
+    fun `when resetCountrySelection is invoked then SelectedCountry should be updated from the billing address`() {
+        // Given
+        val givenSelectedCountry = Country.UKRAINE
+        mockPaymentStateManager.selectedCountry.value = givenSelectedCountry
+        mockPaymentStateManager.billingAddress.value = BillingAddress(
+            address = PaymentFormConfigTestData.address,
+            name = "Test name",
+            phone = PaymentFormConfigTestData.phone
+        )
+
+        // When
+        viewModel.resetCountrySelection()
+
+        // Then
+        assertNotEquals(givenSelectedCountry, mockPaymentStateManager.selectedCountry.value)
     }
 
     @Test


### PR DESCRIPTION
## Issue

[PIMOB-2119](https://checkout.atlassian.net/browse/PIMOB-2119)

## Proposed changes
Problem statement: When the merchant has not added any prefilled data navigates to the billing form and selects the country. Observed that country is updated in the payment form without saving it from the billing form.
Conflict is happening because the country is directly updating in  billing address from the payment state manager

Solution: Added new parameter `selectedCountry` in paymentstatemanager  

## Test Steps
Case 1 (same for prefilled data)
1. open the billing form and select any country
2. Go back to the payment form, the country should not be updated there

Case-2:
1. Open the billing form, select any country and save the billing form (For instance, U.K)
2. Go back to the payment form, the country should  be updated there
3. Open the edit billing form, and change any country (F.i, Ukraine)
4. Goto the payment form without saving any details in the billing form. A country should be the U.K. in the payment form
5. Same when open edit billing form country U.K should be selected


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Reviewers assigned
* [X] I have performed a self-review of my code and manual testing
* [X] Lint and unit tests pass locally with my changes
* [X] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)

## Further comments

_If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered, etc..._


[PIMOB-2119]: https://checkout.atlassian.net/browse/PIMOB-2119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ