### PR TITLE
PIMOB:2123: info text issue for cardholdername in theming capabilities

### DIFF
--- a/frames/src/main/java/com/checkout/frames/mapper/theme/PaymentDetailsStyleMapper.kt
+++ b/frames/src/main/java/com/checkout/frames/mapper/theme/PaymentDetailsStyleMapper.kt
@@ -233,7 +233,7 @@ internal class PaymentDetailsStyleMapper : Mapper<PaymentFormTheme, PaymentDetai
                     this.copy(
                         titleStyle = titleStyle.provideTitleStyle(component, from),
                         subtitleStyle = subtitleStyle.provideSubTitleStyle(component, from),
-                        infoStyle = infoStyle.provideInfoStyle(component, from),
+                        infoStyle = component.infoTextId?.let { infoStyle.provideInfoStyle(component, from) },
                         inputFieldStyle = provideInputFieldStyle(from),
                         errorMessageStyle = errorMessageStyle.provideErrorMessageStyle(from),
                         isInputFieldOptional = component.isFieldOptional


### PR DESCRIPTION
## Issue

[PIMOB-2123](https://checkout.atlassian.net/browse/PIMOB-2123)

## Proposed changes
Steps to reproduce:
1 When loading the cardholder name in the payment form and making it mandatory, remove the info text from the code
2 Although removing info text, in the UI optional text is displaying from the default UI

Solution:
in the payment form, the cardholder's name is able to make itself as optional and mandatory. In this case, if merchants dont want to set info text in theming capabilities, they should able to hide the info text by just not adding info text in theming. 

## Test Steps
In the CustomPaymentFormTheme class comment setInfoTextId from cardHolderName and in the UI info text will not be visible

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Reviewers assigned
* [X] I have performed a self-review of my code and manual testing
* [X] Lint and unit tests pass locally with my changes
* [X] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)

## Further comments

There are no test cases for PaymentDetailsStyleMapper at the moment. We can add into unit testing improvement for Frames. just to make it thoroughly covered by test cases. 


[PIMOB-2123]: https://checkout.atlassian.net/browse/PIMOB-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ