### PR TITLE
PIMOB:2181 - CVV multiple loading support added

### DIFF
--- a/frames/src/androidTest/kotlin/com/checkout/frames/cvvinputfield/CVVInputFieldTest.kt
+++ b/frames/src/androidTest/kotlin/com/checkout/frames/cvvinputfield/CVVInputFieldTest.kt
@@ -1,0 +1,30 @@
+package com.checkout.frames.cvvinputfield
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTextInput
+import com.checkout.base.model.CardScheme
+import com.checkout.frames.cvvinputfield.models.CVVComponentConfig
+import com.checkout.frames.style.component.base.InputFieldStyle
+import org.junit.Rule
+import org.junit.Test
+
+internal class CVVInputFieldTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun testCVVInputField() {
+       // When
+        composeTestRule.setContent {
+            CVVInputField(config = CVVComponentConfig(CardScheme.VISA, {}, InputFieldStyle()))
+        }
+
+        // Then
+        composeTestRule.onNodeWithText("").assertIsDisplayed().assertIsNotFocused().performTextInput("123")
+        composeTestRule.onNodeWithText("123").assertIsDisplayed().assertIsFocused()
+    }
+}

--- a/frames/src/androidTest/kotlin/com/checkout/frames/cvvinputfield/InternalCVVComponentMediatorTest.kt
+++ b/frames/src/androidTest/kotlin/com/checkout/frames/cvvinputfield/InternalCVVComponentMediatorTest.kt
@@ -29,7 +29,6 @@ internal class InternalCVVComponentMediatorTest {
             cvvComponentConfig = cvvComponentConfig, publicKey = "",
             environment = Environment.SANDBOX,
             context = context,
-            isCVVComponentCalled = false
         )
     }
 
@@ -44,7 +43,7 @@ internal class InternalCVVComponentMediatorTest {
         }
 
         // Then
-        assertTrue(cvvComponentMediator.getIsCVVComponentCalled())
+        assertTrue(cvvComponentMediator.getIsCVVComponentCalled().value)
     }
 
     @Test
@@ -58,6 +57,6 @@ internal class InternalCVVComponentMediatorTest {
         }
 
         // Then
-        assertTrue(cvvComponentMediator.getIsCVVComponentCalled())
+        assertTrue(cvvComponentMediator.getIsCVVComponentCalled().value)
     }
 }

--- a/frames/src/androidTest/kotlin/com/checkout/frames/cvvinputfield/InternalCVVComponentMediatorTest.kt
+++ b/frames/src/androidTest/kotlin/com/checkout/frames/cvvinputfield/InternalCVVComponentMediatorTest.kt
@@ -36,7 +36,7 @@ internal class InternalCVVComponentMediatorTest {
     @Test
     fun isCVVComponentCalledValueShouldUpdateWhenCVVComponentInvoked() {
         // Given
-        cvvComponentMediator.isCVVComponentCalled = false
+        cvvComponentMediator.setIsCVVComponentCalled(false)
 
         // When
         composeTestRule.setContent {
@@ -44,13 +44,13 @@ internal class InternalCVVComponentMediatorTest {
         }
 
         // Then
-        assertTrue(cvvComponentMediator.isCVVComponentCalled)
+        assertTrue(cvvComponentMediator.getIsCVVComponentCalled())
     }
 
     @Test
     fun isCVVComponentCalledValueShouldNotUpdateWhenCVVComponentAlreadyInvoked() {
         // Given
-        cvvComponentMediator.isCVVComponentCalled = true
+        cvvComponentMediator.setIsCVVComponentCalled(true)
 
         // When
         composeTestRule.setContent {
@@ -58,6 +58,6 @@ internal class InternalCVVComponentMediatorTest {
         }
 
         // Then
-        assertTrue(cvvComponentMediator.isCVVComponentCalled)
+        assertTrue(cvvComponentMediator.getIsCVVComponentCalled())
     }
 }

--- a/frames/src/androidTest/kotlin/com/checkout/frames/cvvinputfield/InternalCVVComponentMediatorTest.kt
+++ b/frames/src/androidTest/kotlin/com/checkout/frames/cvvinputfield/InternalCVVComponentMediatorTest.kt
@@ -1,0 +1,63 @@
+package com.checkout.frames.cvvinputfield
+
+import android.content.Context
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.platform.app.InstrumentationRegistry
+import com.checkout.base.model.CardScheme
+import com.checkout.base.model.Environment
+import com.checkout.frames.cvvinputfield.api.InternalCVVComponentMediator
+import com.checkout.frames.cvvinputfield.models.CVVComponentConfig
+import com.checkout.frames.style.component.base.InputFieldStyle
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+
+internal class InternalCVVComponentMediatorTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var cvvComponentConfig: CVVComponentConfig
+    private lateinit var cvvComponentMediator: InternalCVVComponentMediator
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = InstrumentationRegistry.getInstrumentation().targetContext
+        cvvComponentConfig = CVVComponentConfig(CardScheme.VISA, {}, InputFieldStyle())
+        cvvComponentMediator = InternalCVVComponentMediator(
+            cvvComponentConfig = cvvComponentConfig, publicKey = "",
+            environment = Environment.SANDBOX,
+            context = context,
+            isCVVComponentCalled = false
+        )
+    }
+
+    @Test
+    fun isCVVComponentCalledValueShouldUpdateWhenCVVComponentInvoked() {
+        // Given
+        cvvComponentMediator.isCVVComponentCalled = false
+
+        // When
+        composeTestRule.setContent {
+            cvvComponentMediator.CVVComponent()
+        }
+
+        // Then
+        assertTrue(cvvComponentMediator.isCVVComponentCalled)
+    }
+
+    @Test
+    fun isCVVComponentCalledValueShouldNotUpdateWhenCVVComponentAlreadyInvoked() {
+        // Given
+        cvvComponentMediator.isCVVComponentCalled = true
+
+        // When
+        composeTestRule.setContent {
+            cvvComponentMediator.CVVComponent()
+        }
+
+        // Then
+        assertTrue(cvvComponentMediator.isCVVComponentCalled)
+    }
+}

--- a/frames/src/androidTest/kotlin/com/checkout/frames/screen/PaymentFormScreenTest.kt
+++ b/frames/src/androidTest/kotlin/com/checkout/frames/screen/PaymentFormScreenTest.kt
@@ -1,4 +1,4 @@
-package com.checkout.frames.screen.paymentform
+package com.checkout.frames.screen
 
 import android.content.Context
 import androidx.compose.material3.MaterialTheme
@@ -9,6 +9,7 @@ import com.checkout.base.model.CardScheme
 import com.checkout.base.model.Country
 import com.checkout.base.model.Environment
 import com.checkout.frames.api.PaymentFlowHandler
+import com.checkout.frames.screen.paymentform.PaymentFormScreen
 import com.checkout.frames.screen.paymentform.model.BillingFormAddress
 import com.checkout.frames.screen.paymentform.model.PaymentFormConfig
 import com.checkout.frames.screen.paymentform.model.PrefillData
@@ -43,18 +44,15 @@ internal class PaymentFormScreenTest {
             override fun onBackPressed() {}
         },
         prefillData = PrefillData(
-            cardHolderName = "Test Name",
-            billingFormAddress = BillingFormAddress(
-                name = "Test Billing Address name",
-                address = Address(
+            cardHolderName = "Test Name", billingFormAddress = BillingFormAddress(
+                name = "Test Billing Address name", address = Address(
                     addressLine1 = "Checkout.com",
                     addressLine2 = "90 Tottenham Court Road",
                     city = "London",
                     state = "London",
                     zip = "W1T 4TJ",
                     country = Country.from(iso3166Alpha2 = "GB")
-                ),
-                phone = Phone(
+                ), phone = Phone(
                     number = "4155552671", country = Country.from(iso3166Alpha2 = "GB")
                 )
             )

--- a/frames/src/androidTest/kotlin/com/checkout/frames/screen/PaymentFormScreenTest.kt
+++ b/frames/src/androidTest/kotlin/com/checkout/frames/screen/PaymentFormScreenTest.kt
@@ -44,15 +44,18 @@ internal class PaymentFormScreenTest {
             override fun onBackPressed() {}
         },
         prefillData = PrefillData(
-            cardHolderName = "Test Name", billingFormAddress = BillingFormAddress(
-                name = "Test Billing Address name", address = Address(
+            cardHolderName = "Test Name",
+            billingFormAddress = BillingFormAddress(
+                name = "Test Billing Address name",
+                address = Address(
                     addressLine1 = "Checkout.com",
                     addressLine2 = "90 Tottenham Court Road",
                     city = "London",
                     state = "London",
                     zip = "W1T 4TJ",
                     country = Country.from(iso3166Alpha2 = "GB")
-                ), phone = Phone(
+                ),
+                phone = Phone(
                     number = "4155552671", country = Country.from(iso3166Alpha2 = "GB")
                 )
             )

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/CVVInputField.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/CVVInputField.kt
@@ -12,6 +12,7 @@ import com.checkout.frames.mapper.InputFieldStyleToInputFieldStateMapper
 import com.checkout.frames.mapper.InputFieldStyleToViewStyleMapper
 import com.checkout.frames.mapper.TextLabelStyleToViewStyleMapper
 import com.checkout.frames.view.InputField
+import java.util.Random
 
 @Composable
 internal fun CVVInputField(
@@ -19,6 +20,7 @@ internal fun CVVInputField(
 ) {
 
     val viewModel: CVVInputFieldViewModel = viewModel(
+        key = "${System.currentTimeMillis()}_${Random().nextInt()}",
         factory = CVVInputFieldViewModelFactory(
             config = config,
             cvvComponentValidator = CVVComponentValidatorFactory.create(),

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/api/CVVComponentMediator.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/api/CVVComponentMediator.kt
@@ -25,7 +25,7 @@ public interface CVVComponentMediator {
     public fun provideCvvComponentContent(
         container: View,
         strategy: ViewCompositionStrategy = ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed,
-    ): View
+    ): View?
 
     /**
      * Creates token for CVV

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/api/InternalCVVComponentMediator.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/api/InternalCVVComponentMediator.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import com.checkout.base.model.Environment
@@ -16,15 +18,16 @@ internal class InternalCVVComponentMediator(
     private val cvvComponentConfig: CVVComponentConfig,
     private val publicKey: String,
     private val environment: Environment,
-    private val context: Context,
-    private var isCVVComponentCalled: Boolean = false,
+    private val context: Context
 ) : CVVComponentMediator {
+
+    private val isCVVComponentCalled: MutableState<Boolean> = mutableStateOf(false)
 
     @Composable
     override fun CVVComponent() {
-        if (!isCVVComponentCalled) {
+        if (!isCVVComponentCalled.value) {
             CVVInputField(cvvComponentConfig)
-            isCVVComponentCalled = true
+            isCVVComponentCalled.value = true
         }
     }
 
@@ -35,7 +38,7 @@ internal class InternalCVVComponentMediator(
     override fun provideCvvComponentContent(
         container: View,
         strategy: ViewCompositionStrategy,
-    ): View? = if (!isCVVComponentCalled) {
+    ): View? = if (!isCVVComponentCalled.value) {
         ComposeView(container.context).apply {
             // Dispose of the Composition when the view's LifecycleOwner is destroyed
             setViewCompositionStrategy(strategy)
@@ -50,6 +53,6 @@ internal class InternalCVVComponentMediator(
 
     @VisibleForTesting
     internal fun setIsCVVComponentCalled(shouldCVVComponentCall: Boolean) {
-        isCVVComponentCalled = shouldCVVComponentCall
+        isCVVComponentCalled.value = shouldCVVComponentCall
     }
 }

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/api/InternalCVVComponentMediator.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/api/InternalCVVComponentMediator.kt
@@ -2,6 +2,7 @@ package com.checkout.frames.cvvinputfield.api
 
 import android.content.Context
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -16,7 +17,7 @@ internal class InternalCVVComponentMediator(
     private val publicKey: String,
     private val environment: Environment,
     private val context: Context,
-    var isCVVComponentCalled: Boolean = false,
+    private var isCVVComponentCalled: Boolean = false,
 ) : CVVComponentMediator {
 
     @Composable
@@ -42,5 +43,13 @@ internal class InternalCVVComponentMediator(
         }
     } else {
         null
+    }
+
+    @VisibleForTesting
+    internal fun getIsCVVComponentCalled() = isCVVComponentCalled
+
+    @VisibleForTesting
+    internal fun setIsCVVComponentCalled(shouldCVVComponentCall: Boolean) {
+        isCVVComponentCalled = shouldCVVComponentCall
     }
 }

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/api/InternalCVVComponentMediator.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/api/InternalCVVComponentMediator.kt
@@ -16,11 +16,15 @@ internal class InternalCVVComponentMediator(
     private val publicKey: String,
     private val environment: Environment,
     private val context: Context,
+    var isCVVComponentCalled: Boolean = false,
 ) : CVVComponentMediator {
 
     @Composable
     override fun CVVComponent() {
-        CVVInputField(cvvComponentConfig)
+        if (!isCVVComponentCalled) {
+            CVVInputField(cvvComponentConfig)
+            isCVVComponentCalled = true
+        }
     }
 
     override fun createToken(request: CVVTokenRequest) {
@@ -29,10 +33,14 @@ internal class InternalCVVComponentMediator(
 
     override fun provideCvvComponentContent(
         container: View,
-        strategy: ViewCompositionStrategy
-    ): View = ComposeView(container.context).apply {
-        // Dispose of the Composition when the view's LifecycleOwner is destroyed
-        setViewCompositionStrategy(strategy)
-        setContent { CVVInputField(cvvComponentConfig) }
+        strategy: ViewCompositionStrategy,
+    ): View? = if (!isCVVComponentCalled) {
+        ComposeView(container.context).apply {
+            // Dispose of the Composition when the view's LifecycleOwner is destroyed
+            setViewCompositionStrategy(strategy)
+            setContent { CVVInputField(cvvComponentConfig) }
+        }
+    } else {
+        null
     }
 }

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/viewmodel/CVVInputFieldViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/viewmodel/CVVInputFieldViewModel.kt
@@ -35,7 +35,14 @@ internal class CVVInputFieldViewModel internal constructor(
     private fun validate() {
         with(cvvComponentConfig) {
             when (cvvComponentValidator.validate(cvvInputFieldState.cvv.value, cardScheme)) {
-                is ValidationResult.Success -> onCVVValueChange(true)
+                is ValidationResult.Success -> {
+                    if (cvvInputFieldState.cvv.value.isNotEmpty()) {
+                        onCVVValueChange(true)
+                    } else {
+                        onCVVValueChange(false)
+                    }
+                }
+
                 is ValidationResult.Failure -> onCVVValueChange(false)
             }
         }

--- a/frames/src/test/java/com/checkout/frames/cvvinputfield/viewmodel/CVVInputFieldViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/cvvinputfield/viewmodel/CVVInputFieldViewModelTest.kt
@@ -194,6 +194,23 @@ internal class CVVInputFieldViewModelTest {
     }
 
     @Test
+    fun `when input cvv is valid for Maestro scheme with zero length then onCvvChange should call onCVVValueChange with false`() {
+        // Given
+        val validCVV = ""
+        val testCardScheme = CardScheme.MAESTRO
+        every { cvvComponentConfig.cardScheme } returns CardScheme.MAESTRO
+        every {
+            mockCVVComponentValidator.validate(eq(validCVV), eq(testCardScheme))
+        } returns ValidationResult.Success(Unit)
+
+        // When
+        viewModel.onCvvChange(validCVV)
+
+        // Then
+        verify { cvvComponentConfig.onCVVValueChange(false) }
+    }
+
+    @Test
     fun `when input cvv is updating from valid to invalid value onCvvChange should call onCVVValueChange with true`() {
         // Given
         val invalidCVV = "1"


### PR DESCRIPTION
## Issue

[PIMOB-2181](https://checkout.atlassian.net/browse/PIMOB-2181)

## Proposed changes
1. Support to load only one CVV component from the same mediator
2. Support to load multiple CVV components from the different mediator
3. Enabled check for empty CVV length for all card schemes. For instance, if the merchant injects the Maestro, on 0 length CVV validation returns false for isCVVValid
4. Covered UI tests

Note: Sample app only load component and full design will be cover in following PRs
## Test Steps
1. To validate load only one CVV component from the same mediator, call `mediator.CVVComponent()` in CVVTokenizationScreen multipletimes. Expected should be one cvv component in the screen
2. To validate load load multiple CVV components from the different mediator, create new mediators in CVVTokenizationScreen and expected output should be multiple CVV components
3. To validate zero length failure for valid schemes, inject Maestro as a scheme and check the log value. Expected should be on zero length it should be false. 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Reviewers assigned
* [X] I have performed a self-review of my code and manual testing
* [X] Lint and unit tests pass locally with my changes
* [X] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)

## Further comments

_If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered, etc..._


[PIMOB-2181]: https://checkout.atlassian.net/browse/PIMOB-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ