### PR TITLE
PIMOB:2168 - Tokenization Logging was implemented for CVV

### DIFF
--- a/checkout/src/main/java/com/checkout/tokenization/logging/TokenizationEventLogger.kt
+++ b/checkout/src/main/java/com/checkout/tokenization/logging/TokenizationEventLogger.kt
@@ -14,6 +14,7 @@ import com.checkout.logging.utils.TOKEN_ID
 import com.checkout.logging.utils.TOKEN_TYPE
 import com.checkout.logging.utils.putErrorAttributes
 import com.checkout.network.response.ErrorResponse
+import com.checkout.tokenization.response.CVVTokenDetailsResponse
 import com.checkout.tokenization.response.TokenDetailsResponse
 
 internal class TokenizationEventLogger(private val logger: Logger<LoggingEvent>) : TokenizationLogger {
@@ -29,9 +30,19 @@ internal class TokenizationEventLogger(private val logger: Logger<LoggingEvent>)
         tokenType: String,
         publicKey: String,
         tokenDetails: TokenDetailsResponse?,
+        cvvTokenDetailsResponse: CVVTokenDetailsResponse?,
         code: Int?,
         errorResponse: ErrorResponse?,
-    ) = logEvent(TokenizationEventType.TOKEN_RESPONSE, tokenType, publicKey, null, tokenDetails, code, errorResponse)
+    ) = logEvent(
+        tokenizationEventType = TokenizationEventType.TOKEN_RESPONSE,
+        tokenType = tokenType,
+        publicKey = publicKey,
+        error = null,
+        tokenDetails = tokenDetails,
+        cvvTokenDetailsResponse = cvvTokenDetailsResponse,
+        code = code,
+        errorResponse = errorResponse,
+    )
 
     override fun resetSession() = logger.resetSession()
 
@@ -41,17 +52,19 @@ internal class TokenizationEventLogger(private val logger: Logger<LoggingEvent>)
         publicKey: String,
         error: Throwable? = null,
         tokenDetails: TokenDetailsResponse? = null,
+        cvvTokenDetailsResponse: CVVTokenDetailsResponse? = null,
         code: Int? = null,
         errorResponse: ErrorResponse? = null,
     ) = logger.log(
         provideLoggingEvent(
-            tokenizationEventType,
-            tokenType,
-            publicKey,
-            error,
-            tokenDetails,
-            code,
-            errorResponse,
+            tokenizationEventType = tokenizationEventType,
+            tokenType = tokenType,
+            publicKey = publicKey,
+            error = error,
+            tokenDetails = tokenDetails,
+            cvvTokenDetails = cvvTokenDetailsResponse,
+            code = code,
+            errorResponse = errorResponse,
         ),
     )
 
@@ -61,6 +74,7 @@ internal class TokenizationEventLogger(private val logger: Logger<LoggingEvent>)
         publicKey: String,
         error: Throwable?,
         tokenDetails: TokenDetailsResponse?,
+        cvvTokenDetails: CVVTokenDetailsResponse?,
         code: Int?,
         errorResponse: ErrorResponse?,
     ): LoggingEvent {
@@ -73,6 +87,10 @@ internal class TokenizationEventLogger(private val logger: Logger<LoggingEvent>)
         tokenDetails?.let {
             properties[TOKEN_ID] = it.token
             properties[SCHEME] = it.scheme ?: ""
+        }
+
+        cvvTokenDetails?.let {
+            properties[TOKEN_ID] = it.token
         }
 
         code?.let {

--- a/checkout/src/main/java/com/checkout/tokenization/logging/TokenizationLogger.kt
+++ b/checkout/src/main/java/com/checkout/tokenization/logging/TokenizationLogger.kt
@@ -1,6 +1,7 @@
 package com.checkout.tokenization.logging
 
 import com.checkout.network.response.ErrorResponse
+import com.checkout.tokenization.response.CVVTokenDetailsResponse
 import com.checkout.tokenization.response.TokenDetailsResponse
 
 /**
@@ -25,6 +26,7 @@ internal interface TokenizationLogger {
         tokenType: String,
         publicKey: String,
         tokenDetails: TokenDetailsResponse? = null,
+        cvvTokenDetailsResponse: CVVTokenDetailsResponse? = null,
         code: Int? = null,
         errorResponse: ErrorResponse? = null,
     )

--- a/checkout/src/test/java/com/checkout/tokenization/logging/TokenizationEventLoggerTest.kt
+++ b/checkout/src/test/java/com/checkout/tokenization/logging/TokenizationEventLoggerTest.kt
@@ -179,11 +179,12 @@ internal class TokenizationEventLoggerTest {
 
         // When
         tokenizationEventLogger.logTokenResponseEvent(
-            tokenType,
-            "test_key",
-            null,
-            501,
-            TokenizationRequestTestData.errorResponse(),
+            tokenType = tokenType,
+            publicKey = "test_key",
+            tokenDetails = null,
+            cvvTokenDetailsResponse = null,
+            code = 501,
+            errorResponse = TokenizationRequestTestData.errorResponse(),
         )
 
         // Then

--- a/example_app_frames/src/main/java/com/checkout/example/frames/styling/CustomCVVInputFieldStyle.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/styling/CustomCVVInputFieldStyle.kt
@@ -20,7 +20,7 @@ object CustomCVVInputFieldStyle {
     fun create() = InputFieldStyle(
         placeholderTextId = R.string.enter_cvv_here,
         textStyle = TextStyle(16, color = textColor, font = Font.Cursive),
-        placeholderStyle = TextStyle(16, color = placeHolderTextColor, font = Font.Cursive),
+        placeholderStyle = TextStyle(16, color = placeHolderTextColor, font = Font.Monospace),
         containerStyle = ContainerStyle(
             width = 250,
             color = backgroundColor,

--- a/frames/src/test/java/com/checkout/frames/mapper/BillingFormAddressToBillingAddressMapperTest.kt
+++ b/frames/src/test/java/com/checkout/frames/mapper/BillingFormAddressToBillingAddressMapperTest.kt
@@ -53,6 +53,7 @@ internal class BillingFormAddressToBillingAddressMapperTest {
     }
 
     companion object {
+        @Suppress("LongMethod")
         @JvmStatic
         fun testBillingAddressSummaryArguments(): Stream<Arguments> = Stream.of(
             Arguments.of(


### PR DESCRIPTION
## Issue

[PIMOB-2168](https://checkout.atlassian.net/browse/PIMOB-2168)

## Proposed changes
Logged below data
1. Token request  
2. Token response (Success and failure)


## Test Steps
Check logs"
1 Failure server error response [logs](https://app.datadoghq.com/logs?query=%40ApplicationName%3Acloudevents%20%40platform%3AAndroid%20%40productVersion%3A4.1.0%20%40appPackageName%3Acom.checkout.example.frames%20&agg_q=%40cloudevent.type&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%5D&cols=host%2Cservice&event=AgAAAYsaX1aQKbyifgAAAAAAAAAYAAAAAEFZc2FYNmpIQUFEdUpxMFFFeWtsQndFQgAAACQAAAAAMDE4YjFhNjgtN2VkNS00OTRjLTgwOTUtMDY1NmViZThlMjgw&index=&messageDisplay=inline&panel=%7B%22queryString%22%3A%22%40cloudevent.type%3Acom.checkout.checkout-android.token_response%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22cloudevent.type%22%2C%22value%22%3A%22com.checkout.checkout-android.token_response%22%7D%5D%2C%22timeRange%22%3A%7B%22from%22%3A1696954291200%2C%22to%22%3A1696955191200%2C%22live%22%3Atrue%7D%7D&refresh_mode=sliding&storage=hot&stream_sort=service%2Casc&viz=query_table&from_ts=1696953215614&to_ts=1696954115614&live=true)
2 Success tokenisation response ([logs](https://app.datadoghq.com/logs?query=%40ApplicationName%3Acloudevents%20%40platform%3AAndroid%20%40productVersion%3A4.1.0%20%40appPackageName%3Acom.checkout.example.frames%20&agg_q=%40cloudevent.type&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%5D&cols=host%2Cservice&event=AgAAAYsamL3h9PS8kgAAAAAAAAAYAAAAAEFZc2FtWmtsQUFDOWYyY0k4cFY2NndCXwAAACQAAAAAMDE4YjFhOWQtYzZlNS00MjAwLWIzZmItZTFmMjJlNGVkNDli&index=&messageDisplay=inline&panel=%7B%22queryString%22%3A%22%40cloudevent.type%3Acom.checkout.checkout-android.token_response%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22cloudevent.type%22%2C%22value%22%3A%22com.checkout.checkout-android.token_response%22%7D%5D%2C%22timeRange%22%3A%7B%22from%22%3A1696957725600%2C%22to%22%3A1696958625600%2C%22live%22%3Atrue%7D%7D&refresh_mode=sliding&storage=hot&stream_sort=service%2Casc&viz=query_table&from_ts=1696953215614&to_ts=1696954115614&live=true))
3. Token request [logs](https://app.datadoghq.com/logs?query=%40ApplicationName%3Acloudevents%20%40platform%3AAndroid%20%40productVersion%3A4.1.0%20%40appPackageName%3Acom.checkout.example.frames%20&agg_q=%40cloudevent.type&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%5D&cols=host%2Cservice&event=AgAAAYsamL1w9PS8vwAAAAAAAAAYAAAAAEFZc2FtWmtsQUFDOWYyY0k4cFY2NndDcwAAACQAAAAAMDE4YjFhOWQtYzZlNS00MjAwLWIzZmItZTFmMjJlNGVkNDli&index=&messageDisplay=inline&panel=%7B%22queryString%22%3A%22%40cloudevent.type%3Acom.checkout.checkout-android.token_requested%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22cloudevent.type%22%2C%22value%22%3A%22com.checkout.checkout-android.token_requested%22%7D%5D%2C%22timeRange%22%3A%7B%22from%22%3A1696957785000%2C%22to%22%3A1696958685000%2C%22live%22%3Atrue%7D%7D&refresh_mode=sliding&storage=hot&stream_sort=service%2Casc&viz=query_table&from_ts=1696953215614&to_ts=1696954115614&live=true)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x] Reviewers assigned
* [x] I have performed a self-review of my code and manual testing
* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)

## Further comments

_If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered, etc..._


[PIMOB-2168]: https://checkout.atlassian.net/browse/PIMOB-2168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ