### PR TITLE
PIMOB: 2196: Borderstroke issue fixed

### DIFF
--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/CVVTokenizationScreen.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/CVVTokenizationScreen.kt
@@ -17,6 +17,7 @@ import com.checkout.frames.cvvinputfield.api.CVVComponentApi
 import com.checkout.frames.cvvinputfield.api.CVVComponentMediator
 import com.checkout.frames.cvvinputfield.models.CVVComponentConfig
 import com.checkout.frames.cvvinputfield.style.DefaultCVVInputFieldStyle
+import com.checkout.frames.model.BorderStroke
 import com.checkout.frames.model.CornerRadius
 import com.checkout.frames.model.Padding
 import com.checkout.frames.model.Shape
@@ -25,7 +26,7 @@ import com.checkout.frames.style.component.base.ContainerStyle
 import com.checkout.frames.style.component.base.InputFieldStyle
 import com.checkout.frames.style.component.base.TextStyle
 
-@Suppress("MagicNumber")
+@Suppress("MagicNumber", "LongMethod")
 @Composable
 fun CVVTokenizationScreen(navController: NavHostController) {
     val cvvTokenizationViewModel: CVVTokenizationViewModel = viewModel()
@@ -78,6 +79,10 @@ fun CVVTokenizationScreen(navController: NavHostController) {
                 color = PaymentFormConstants.backgroundColor,
                 shape = Shape.Circle,
                 cornerRadius = CornerRadius(9),
+                borderStroke = BorderStroke(
+                    width = 2,
+                    color = 0XFF00CC2D,
+                ),
             ),
         ),
     )

--- a/frames/src/main/java/com/checkout/frames/mapper/InputFieldStyleToViewStyleMapper.kt
+++ b/frames/src/main/java/com/checkout/frames/mapper/InputFieldStyleToViewStyleMapper.kt
@@ -2,6 +2,7 @@ package com.checkout.frames.mapper
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -26,6 +27,7 @@ import com.checkout.frames.utils.extensions.disabledIndicatorColor
 import com.checkout.frames.utils.extensions.errorIndicatorColor
 import com.checkout.frames.utils.extensions.focusedIndicatorColor
 import com.checkout.frames.utils.extensions.toComposeShape
+import com.checkout.frames.utils.extensions.toComposeStroke
 import com.checkout.frames.utils.extensions.toComposeTextStyle
 import com.checkout.frames.utils.extensions.unfocusedIndicatorColor
 import com.checkout.frames.view.TextLabel
@@ -51,11 +53,13 @@ internal class InputFieldStyleToViewStyleMapper(
     @SuppressLint("ModifierFactoryExtensionFunction")
     private fun provideModifier(containerStyle: ContainerStyle): Modifier = with(containerStyle) {
         var modifier = Modifier.background(Color.Transparent)
-
+        val composeShape = shape.toComposeShape(cornerRadius)
         height?.let { modifier = modifier.height(it.dp) }
         modifier = width?.let { modifier.width(it.dp) } ?: modifier.fillMaxWidth()
         margin?.let { modifier = modifier.padding(it.start.dp, it.top.dp, it.end.dp, it.bottom.dp) }
         padding?.let { modifier = modifier.padding(it.start.dp, it.top.dp, it.end.dp, it.bottom.dp) }
+
+        borderStroke?.let { modifier = modifier.border(it.toComposeStroke(), composeShape) }
 
         return modifier
     }


### PR DESCRIPTION
## Issue

[PIMOB-2196](https://checkout.atlassian.net/browse/PIMOB-2196)

## Proposed changes
Support added in mapper for borderstorke in inputfield

## Test Steps
Add borderstorke in containerstyle and see the change as below in screenshot

<img width="360" alt="Screenshot 2023-10-16 at 12 02 45" src="https://github.com/checkout/frames-android/assets/114917119/1e3a08e1-7de0-4fd6-94bc-c46b93190ab8">



## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Reviewers assigned
* [X] I have performed a self-review of my code and manual testing
* [X] Lint and unit tests pass locally with my changes
* [X] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)

## Further comments

_If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered, etc..._


[PIMOB-2196]: https://checkout.atlassian.net/browse/PIMOB-2196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ