### PR TITLE
PIMOB:2356 - add guide for disable the cardholder and billing form in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,17 @@ val customInputComponentStyle = DefaultLightStyle.inputComponentStyle(
 paymentFormStyle.paymentDetailsStyle.cardNumberStyle.inputStyle = customInputComponentStyle
 ```
 
+To disable the `cardHolderName` and `BillingFormAddress` in the Payment Form, pass null value to respective style property in `PaymentDetailsStyle`
+
+```kotlin
+val paymentFormStyle = PaymentFormStyle(
+    paymentDetailsStyle =  PaymentDetailsStyle(
+        addressSummaryStyle = null,
+        cardHolderNameStyle = null
+    )
+)
+```
+
 ### Use Theme
 Detailed implementation of this approach can be found in `CustomPaymentFormTheme.kt`. With the Theme, we are aiming to give you a design system that you can use to create the full UI style by providing a small number of properties that we will share across to sub components. Since you might not fully agree with our mapping, you can still individually change each component afterwards (as in the Modify Default example).
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ val customInputComponentStyle = DefaultLightStyle.inputComponentStyle(
 paymentFormStyle.paymentDetailsStyle.cardNumberStyle.inputStyle = customInputComponentStyle
 ```
 
-To disable the `cardHolderName` and `BillingFormAddress` in the Payment Form, pass null value to respective style property in `PaymentDetailsStyle`
+To disable `cardHolderName` and `BillingFormAddress` in the Payment Form, pass a null value to each respective style property in `PaymentDetailsStyle`
 
 ```kotlin
 val paymentFormStyle = PaymentFormStyle(


### PR DESCRIPTION
## Issue

[PIMOB-2356](https://checkout.atlassian.net/browse/PIMOB-2356)

## Proposed changes

Added details how to disable the cardholdername and billing form in payment form. Not included the part of disabling the fields in billing form because in details guide with code is available via [public doc ](https://www.checkout.com/docs/developer-resources/sdks/frames-android-sdk/customize-the-frames-android-sdk#Custom_BillingFormStyle)

[Preview link](https://github.com/checkout/frames-android/blob/c3fdc593e6b76e43f9df46fe96ce52b961ac6c98/README.md)
## Test Steps
N/A

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Reviewers assigned
* [X] I have added necessary documentation (if applicable)

## Further comments

_If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered, etc..._


[PIMOB-2356]: https://checkout.atlassian.net/browse/PIMOB-2356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ