### PR TITLE
feature/PIMOB-2024_UserAgent_with_incorrect_format

### DIFF
--- a/checkout/src/main/java/com/checkout/network/utils/OkHttpConstants.kt
+++ b/checkout/src/main/java/com/checkout/network/utils/OkHttpConstants.kt
@@ -1,5 +1,7 @@
 package com.checkout.network.utils
 
+import com.checkout.BuildConfig
+
 internal object OkHttpConstants {
     const val CALL_TIMEOUT_MS = 10000L
     const val CONNECTION_TIMEOUT_MS = 10000L
@@ -7,5 +9,5 @@ internal object OkHttpConstants {
 
     const val HEADER_AUTHORIZATION = "Authorization"
     const val HEADER_USER_AGENT_NAME = "User-Agent"
-    const val HEADER_USER_AGENT_VALUE = "checkout-android-sdk"
+    const val HEADER_USER_AGENT_VALUE = "checkout-sdk-android/${BuildConfig.PRODUCT_VERSION}"
 }


### PR DESCRIPTION
## Issue

PIMOB-2024

## Proposed changes

Changing the value of HEADER_USER_AGENT_VALUE in order to be consistent with the IOS counter part
[Originally](https://github.com/checkout/frames-android/blob/release/3.1.1/android-sdk/src/main/java/com/checkout/android_sdk/network/utils/OkHttpTokenRequestor.kt) the version was part of the header user agent but from the refactor to 4.x.x this value has been lost.

## Test Steps

- Install the sample app 
- Generate a token
- Verify that the user agent has the new and correct format ([here](https://app.datadoghq.com/logs?query=%40UserAgent%3A%2A4.2.0%2A%20&agg_q=%40UserAgent&cols=host%2Cservice%2C%40UserAgent&fromUser=true&index=&messageDisplay=inline&refresh_mode=sliding&sort_m=&sort_t=&stream_sort=service%2Cdesc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1708615769279&to_ts=1708616669279&live=true))

## Checklist

* [x] Reviewers assigned
* [x] I have performed a self-review of my code and manual testing
* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)

