### PR TITLE
PRISM-11149 - Pass correlationID to Risk for logging

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -36,7 +36,7 @@ object Versions {
     const val moshi = "1.15.1"
 
     // Risk SDK Dependencies
-    const val riskSdk = "1.0.4"
+    const val riskSdk = "1.0.6"
 
     // Unit Testing Dependencies
     const val junit5Jupiter = "5.8.0"

--- a/checkout/src/main/java/com/checkout/CheckoutApiServiceFactory.kt
+++ b/checkout/src/main/java/com/checkout/CheckoutApiServiceFactory.kt
@@ -29,8 +29,11 @@ import com.checkout.tokenization.usecase.ValidateTokenizationDataUseCase
 import com.checkout.validation.validator.AddressValidator
 import com.checkout.validation.validator.PhoneValidator
 import com.squareup.moshi.Moshi
+import java.util.UUID
 
 public object CheckoutApiServiceFactory {
+    private val correlationId = UUID.randomUUID().toString()
+
     @JvmStatic
     public fun create(
         publicKey: String,
@@ -39,7 +42,7 @@ public object CheckoutApiServiceFactory {
     ): CheckoutApiService {
         val logger = EventLoggerProvider.provide()
 
-        logger.setup(context, environment)
+        logger.setup(context, environment, correlationId = correlationId)
 
         return CheckoutApiClient(
             provideTokenRepository(context, publicKey, environment),
@@ -68,7 +71,7 @@ public object CheckoutApiServiceFactory {
         logger = TokenizationEventLogger(EventLoggerProvider.provide()),
         publicKey = publicKey,
         cvvTokenizationNetworkDataMapper = CVVTokenizationNetworkDataMapper(),
-        riskSdkUseCase = RiskSdkUseCase(environment, context, publicKey, RiskInstanceProvider),
+        riskSdkUseCase = RiskSdkUseCase(environment, context, publicKey, correlationId, RiskInstanceProvider),
     )
 
     private fun provideNetworkApiClient(

--- a/checkout/src/main/java/com/checkout/logging/EventLogger.kt
+++ b/checkout/src/main/java/com/checkout/logging/EventLogger.kt
@@ -18,12 +18,17 @@ internal class EventLogger(private val logger: CheckoutEventLogger) : Logger<Log
     @VisibleForTesting
     var needToSetup = true
 
+    @VisibleForTesting
+    var correlationId: String = UUID.randomUUID().toString()
+
     override fun setup(
         context: Context,
         environment: Environment,
+        correlationId: String,
         identifier: String,
         version: String,
     ) {
+        this.correlationId = correlationId
         if (needToSetup) {
             logger.enableRemoteProcessor(
                 environment.toLoggingEnvironment(),
@@ -35,7 +40,6 @@ internal class EventLogger(private val logger: CheckoutEventLogger) : Logger<Log
     }
 
     override fun resetSession() {
-        val correlationId = UUID.randomUUID().toString()
         logger.addMetadata(METADATA_CORRELATION_ID, correlationId)
         sentLogs.clear()
     }

--- a/checkout/src/main/java/com/checkout/logging/Logger.kt
+++ b/checkout/src/main/java/com/checkout/logging/Logger.kt
@@ -18,10 +18,12 @@ public interface Logger<T> {
      * @param environment - [Environment] type.
      * @param identifier - [String] library logging identifier, used as a prefix for an event type.
      * @param version - [String] library version.
+     * @param correlationId - [String] correlationId for metadata logs
      */
     public fun setup(
         context: Context,
         environment: Environment,
+        correlationId: String,
         identifier: String = BuildConfig.PRODUCT_IDENTIFIER,
         version: String = BuildConfig.PRODUCT_VERSION,
     )

--- a/checkout/src/main/java/com/checkout/tokenization/usecase/RiskInstanceProvider.kt
+++ b/checkout/src/main/java/com/checkout/tokenization/usecase/RiskInstanceProvider.kt
@@ -13,6 +13,7 @@ internal object RiskInstanceProvider {
         context: Context,
         publicKey: String,
         environment: Environment,
+        correlationId: String,
     ): Risk? {
         if (riskInstance != null) {
             return riskInstance
@@ -31,6 +32,7 @@ internal object RiskInstanceProvider {
                     publicKey = publicKey,
                     environment = riskEnvironment,
                     framesMode = true,
+                    correlationId = correlationId,
                 ),
             )
         return riskInstance

--- a/checkout/src/main/java/com/checkout/tokenization/usecase/RiskSdkUseCase.kt
+++ b/checkout/src/main/java/com/checkout/tokenization/usecase/RiskSdkUseCase.kt
@@ -12,11 +12,12 @@ internal class RiskSdkUseCase(
     private val environment: Environment,
     private val context: Context,
     private val publicKey: String,
+    private val correlationId: String,
     private val riskInstanceProvider: RiskInstanceProvider,
 ) : UseCase<TokenResult<String>, Unit> {
     override fun execute(data: TokenResult<String>) {
         CoroutineScope(Dispatchers.IO).launch {
-            val riskInstance = riskInstanceProvider.provide(context, publicKey, environment)
+            val riskInstance = riskInstanceProvider.provide(context, publicKey, environment, correlationId)
             when (data) {
                 is TokenResult.Success -> {
                     riskInstance?.publishData(cardToken = data.result)

--- a/checkout/src/test/java/com/checkout/CheckoutApiServiceFactoryTest.kt
+++ b/checkout/src/test/java/com/checkout/CheckoutApiServiceFactoryTest.kt
@@ -32,11 +32,12 @@ internal class CheckoutApiServiceFactoryTest {
         // Given
         val mockContext = mockk<Context>()
         val mockEnvironment = Environment.SANDBOX
+        val mockCorrelationId = "testCorrelationId"
 
         // When
         CheckoutApiServiceFactory.create("", mockEnvironment, mockContext)
 
         // Then
-        verify { mockLogger.setup(eq(mockContext), eq(mockEnvironment)) }
+        verify { mockLogger.setup(eq(mockContext), eq(mockEnvironment), eq(mockCorrelationId)) }
     }
 }

--- a/checkout/src/test/java/com/checkout/logging/EventLoggerTest.kt
+++ b/checkout/src/test/java/com/checkout/logging/EventLoggerTest.kt
@@ -39,6 +39,7 @@ internal class EventLoggerTest {
         // Given
         val mockContext: Context = mockk(relaxed = true)
         val mockEnvironment = Environment.SANDBOX
+        val mockCorrelationId = "testCorrelationId"
         val expectedMetadata =
             RemoteProcessorMetadata.from(
                 mockContext,
@@ -48,7 +49,7 @@ internal class EventLoggerTest {
             )
 
         // When
-        eventLogger.setup(mockContext, mockEnvironment)
+        eventLogger.setup(mockContext, mockEnvironment, mockCorrelationId)
 
         // Then
         verify {
@@ -64,9 +65,10 @@ internal class EventLoggerTest {
         // Given
         val mockContext: Context = mockk(relaxed = true)
         val mockEnvironment = Environment.PRODUCTION
+        val mockCorrelationId = "testCorrelationId"
 
         // When
-        eventLogger.setup(mockContext, mockEnvironment)
+        eventLogger.setup(mockContext, mockEnvironment, mockCorrelationId)
 
         // Then
         verify { eventLogger.resetSession() }
@@ -77,10 +79,11 @@ internal class EventLoggerTest {
         // Given
         val mockContext: Context = mockk(relaxed = true)
         val mockEnvironment = Environment.SANDBOX
+        val mockCorrelationId = "testCorrelationId"
         (eventLogger as? EventLogger)?.needToSetup = false
 
         // When
-        eventLogger.setup(mockContext, mockEnvironment)
+        eventLogger.setup(mockContext, mockEnvironment, mockCorrelationId)
 
         // Then
         verify(exactly = 0) { eventLogger.resetSession() }

--- a/checkout/src/test/java/com/checkout/tokenization/RiskSdkUseCaseTest.kt
+++ b/checkout/src/test/java/com/checkout/tokenization/RiskSdkUseCaseTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 public class RiskSdkUseCaseTest {
+    private val correlationId: String = "testCorrelationId"
     private val environment: Environment = Environment.SANDBOX
     private val riskInstanceProvider: RiskInstanceProvider = mockk()
     private val riskInstance: Risk = mockk()
@@ -27,7 +28,7 @@ public class RiskSdkUseCaseTest {
     @BeforeEach
     public fun setup() {
         coEvery { tokenDetails.token } returns TOKEN
-        coEvery { riskInstanceProvider.provide(context, PUBLIC_KEY, environment) } returns riskInstance
+        coEvery { riskInstanceProvider.provide(context, PUBLIC_KEY, environment, correlationId) } returns riskInstance
         coEvery { riskInstance.publishData(any()) } returns mockk()
         useCase =
             RiskSdkUseCase(
@@ -35,6 +36,7 @@ public class RiskSdkUseCaseTest {
                 context = context,
                 publicKey = PUBLIC_KEY,
                 riskInstanceProvider = riskInstanceProvider,
+                correlationId = correlationId,
             )
     }
 
@@ -42,7 +44,7 @@ public class RiskSdkUseCaseTest {
     public fun `Success result should trigger publishData`() {
         runBlocking {
             useCase.execute(TokenResult.Success(tokenDetails.token))
-            coVerify { riskInstanceProvider.provide(context, PUBLIC_KEY, environment) }
+            coVerify { riskInstanceProvider.provide(context, PUBLIC_KEY, environment, correlationId) }
             coVerify { riskInstance.publishData(TOKEN) }
         }
     }

--- a/frames/src/main/java/com/checkout/frames/api/PaymentFormMediator.kt
+++ b/frames/src/main/java/com/checkout/frames/api/PaymentFormMediator.kt
@@ -15,6 +15,7 @@ import com.checkout.threedsecure.ThreeDSExecutor
 import com.checkout.threedsecure.logging.ThreeDSEventLogger
 import com.checkout.threedsecure.model.ThreeDSRequest
 import com.checkout.threedsecure.usecase.ProcessThreeDSUseCase
+import java.util.UUID
 
 public class PaymentFormMediator(
     private val config: PaymentFormConfig,
@@ -24,8 +25,9 @@ public class PaymentFormMediator(
      * 3DS executor which can be used to execute and handle 3DS flow with WebView.
      */
     private val threeDSExecutor: Executor<ThreeDSRequest> by lazy(LazyThreadSafetyMode.NONE) {
+        val correlationId = UUID.randomUUID().toString()
         val logger = EventLoggerProvider.provide().apply {
-            setup(config.context, config.environment)
+            setup(config.context, config.environment, correlationId = correlationId)
         }
         ThreeDSExecutor(ProcessThreeDSUseCase(), ThreeDSEventLogger(logger))
     }

--- a/frames/src/main/java/com/checkout/frames/di/injector/FramesInjector.kt
+++ b/frames/src/main/java/com/checkout/frames/di/injector/FramesInjector.kt
@@ -28,6 +28,7 @@ import com.checkout.frames.usecase.CardTokenizationUseCase
 import com.checkout.frames.usecase.ClosePaymentFlowUseCase
 import com.checkout.frames.utils.extensions.logEvent
 import com.checkout.logging.EventLoggerProvider
+import java.util.UUID
 
 internal class FramesInjector(private val component: FramesDIComponent) : Injector {
 
@@ -58,8 +59,15 @@ internal class FramesInjector(private val component: FramesDIComponent) : Inject
             supportedCardSchemeList: List<CardScheme> = emptyList(),
             prefillData: PrefillData? = null,
         ): Injector {
+            val correlationId = UUID.randomUUID().toString()
             val logger = EventLoggerProvider.provide().apply {
-                setup(context, environment, BuildConfig.LOGGING_IDENTIFIER, BuildConfig.PRODUCT_VERSION)
+                setup(
+                    context,
+                    environment,
+                    correlationId = correlationId,
+                    BuildConfig.LOGGING_IDENTIFIER,
+                    BuildConfig.PRODUCT_VERSION,
+                )
                 logEvent(PaymentFormEventType.INITIALISED)
             }
             val closePaymentFlowUseCase = ClosePaymentFlowUseCase(paymentFlowHandler::onBackPressed)


### PR DESCRIPTION
## Issue

https://checkout.atlassian.net/browse/PRISM-11149

## Proposed changes

Pass correlationID to the Risk package which would log it along with other information currently being published.

## Test Steps

No functionality change, tests updated.

## Checklist

* [x] Reviewers assigned
* [x] I have performed a self-review of my code and manual testing
* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have added necessary documentation (if applicable)

## Further comments

No functionality change, the correlationID was previously generated within an abstracted method, we are pulling this upwards so that we can pass it down to the Risk package.