### PR TITLE
[RELEASE-28318] Release 4.2.2 - update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Add JitPack repository to the project level `build.gradle` file:
 allprojects {
     repositories {
         maven { url 'https://jitpack.io' }
+        maven { url 'https://maven.fpregistry.io/releases' }
     }
 }
 ```


### PR DESCRIPTION
## Issue

[Release-28318](https://checkout.atlassian.net/browse/RELEASE-28318)

## Proposed changes

Including `maven { url 'https://maven.fpregistry.io/releases' }` in the readme to access dependency for Risk SDK.