### PR TITLE
feature/PIMOB-2639_Fix_for_phone_numeber_on_RTL_languages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-//import com.vanniktech.code.quality.tools.CodeQualityToolsPluginExtension
+import com.vanniktech.code.quality.tools.CodeQualityToolsPluginExtension
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
@@ -12,7 +12,7 @@ buildscript {
     dependencies {
         classpath(ProjectDependencies.androidGradlePlugin)
         classpath(ProjectDependencies.kotlinGradlePlugin)
-//        classpath(ProjectDependencies.codeQualityToolsPlugin)
+        classpath(ProjectDependencies.codeQualityToolsPlugin)
         classpath(ProjectDependencies.dokkaPlugin)
         classpath(ProjectDependencies.dokkaKotlinPlugin)
 
@@ -49,42 +49,42 @@ tasks.register("clean", Delete::class) {
 
 /* Code quality tools config */
 
-//apply(plugin = ProjectDependencies.codeQualityTools)
-//
-//configure<CodeQualityToolsPluginExtension> {
-//    failEarly = true
-//    xmlReports = false
-//    htmlReports = true
-//    textReports = false
-//    ignoreProjects = listOf("buildSrc", "app")
-//
-//    checkstyle {
-//        enabled = false
-//    }
-//    pmd {
-//        enabled = false
-//    }
-//    lint {
-//        enabled = true
-//        baselineFileName = "lint-baseline.xml"
-//    }
-//    ktlint {
-//        enabled = true
-//        toolVersion = Versions.ktlint
-//    }
-//    detekt {
-//        enabled = true
-//        toolVersion = Versions.detect
-//        config = "code_quality_tools/detekt.yml"
-//        failFast = true
-//    }
-//    cpd {
-//        enabled = false
-//    }
-//    kotlin {
-//        allWarningsAsErrors = true
-//    }
-//}
+apply(plugin = ProjectDependencies.codeQualityTools)
+
+configure<CodeQualityToolsPluginExtension> {
+    failEarly = true
+    xmlReports = false
+    htmlReports = true
+    textReports = false
+    ignoreProjects = listOf("buildSrc", "app")
+
+    checkstyle {
+        enabled = false
+    }
+    pmd {
+        enabled = false
+    }
+    lint {
+        enabled = true
+        baselineFileName = "lint-baseline.xml"
+    }
+    ktlint {
+        enabled = true
+        toolVersion = Versions.ktlint
+    }
+    detekt {
+        enabled = true
+        toolVersion = Versions.detect
+        config = "code_quality_tools/detekt.yml"
+        failFast = true
+    }
+    cpd {
+        enabled = false
+    }
+    kotlin {
+        allWarningsAsErrors = true
+    }
+}
 
 /* Documentation config */
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.vanniktech.code.quality.tools.CodeQualityToolsPluginExtension
+//import com.vanniktech.code.quality.tools.CodeQualityToolsPluginExtension
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
@@ -12,7 +12,7 @@ buildscript {
     dependencies {
         classpath(ProjectDependencies.androidGradlePlugin)
         classpath(ProjectDependencies.kotlinGradlePlugin)
-        classpath(ProjectDependencies.codeQualityToolsPlugin)
+//        classpath(ProjectDependencies.codeQualityToolsPlugin)
         classpath(ProjectDependencies.dokkaPlugin)
         classpath(ProjectDependencies.dokkaKotlinPlugin)
 
@@ -49,42 +49,42 @@ tasks.register("clean", Delete::class) {
 
 /* Code quality tools config */
 
-apply(plugin = ProjectDependencies.codeQualityTools)
-
-configure<CodeQualityToolsPluginExtension> {
-    failEarly = true
-    xmlReports = false
-    htmlReports = true
-    textReports = false
-    ignoreProjects = listOf("buildSrc", "app")
-
-    checkstyle {
-        enabled = false
-    }
-    pmd {
-        enabled = false
-    }
-    lint {
-        enabled = true
-        baselineFileName = "lint-baseline.xml"
-    }
-    ktlint {
-        enabled = true
-        toolVersion = Versions.ktlint
-    }
-    detekt {
-        enabled = true
-        toolVersion = Versions.detect
-        config = "code_quality_tools/detekt.yml"
-        failFast = true
-    }
-    cpd {
-        enabled = false
-    }
-    kotlin {
-        allWarningsAsErrors = true
-    }
-}
+//apply(plugin = ProjectDependencies.codeQualityTools)
+//
+//configure<CodeQualityToolsPluginExtension> {
+//    failEarly = true
+//    xmlReports = false
+//    htmlReports = true
+//    textReports = false
+//    ignoreProjects = listOf("buildSrc", "app")
+//
+//    checkstyle {
+//        enabled = false
+//    }
+//    pmd {
+//        enabled = false
+//    }
+//    lint {
+//        enabled = true
+//        baselineFileName = "lint-baseline.xml"
+//    }
+//    ktlint {
+//        enabled = true
+//        toolVersion = Versions.ktlint
+//    }
+//    detekt {
+//        enabled = true
+//        toolVersion = Versions.detect
+//        config = "code_quality_tools/detekt.yml"
+//        failFast = true
+//    }
+//    cpd {
+//        enabled = false
+//    }
+//    kotlin {
+//        allWarningsAsErrors = true
+//    }
+//}
 
 /* Documentation config */
 

--- a/frames/src/main/java/com/checkout/frames/component/addresssummary/AddressSummaryViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/component/addresssummary/AddressSummaryViewModel.kt
@@ -1,5 +1,6 @@
 package com.checkout.frames.component.addresssummary
 
+import android.text.BidiFormatter
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -26,13 +27,13 @@ internal class AddressSummaryViewModel @Inject constructor(
     val componentState = provideState(style)
     val componentStyle = provideViewStyle(style)
 
-    fun prepare() = viewModelScope.launch {
+    fun prepare(bidiFormatter: BidiFormatter = BidiFormatter.getInstance()) = viewModelScope.launch {
         paymentStateManager.billingAddress.collect { billingAddress ->
             componentState.addressPreviewState.text.value =
                 if (paymentStateManager.billingAddress.value.isEdited() &&
                     paymentStateManager.isBillingAddressEnabled.value
                 ) {
-                    billingAddress.summary()
+                    billingAddress.summary(bidiFormatter)
                 } else {
                     ""
                 }

--- a/frames/src/main/java/com/checkout/frames/utils/extensions/BillingAddressExtensions.kt
+++ b/frames/src/main/java/com/checkout/frames/utils/extensions/BillingAddressExtensions.kt
@@ -5,7 +5,7 @@ import android.text.TextDirectionHeuristics
 import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress
 import java.util.Locale
 
-internal fun BillingAddress.summary(): String {
+internal fun BillingAddress.summary(bidiFormatter: BidiFormatter = BidiFormatter.getInstance()): String {
     val strBuilder = StringBuilder()
 
     // Full name
@@ -25,7 +25,6 @@ internal fun BillingAddress.summary(): String {
     // Phone
     this.phone?.let { phone ->
         if (phone.number.isNotEmpty()) {
-            val bidiFormatter = BidiFormatter.getInstance()
             val phoneText = if (phone.country?.dialingCode?.isNotEmpty() == true) {
                 bidiFormatter.unicodeWrap("+${phone.country?.dialingCode} ${phone.number}", TextDirectionHeuristics.LTR)
             } else {

--- a/frames/src/main/java/com/checkout/frames/utils/extensions/BillingAddressExtensions.kt
+++ b/frames/src/main/java/com/checkout/frames/utils/extensions/BillingAddressExtensions.kt
@@ -5,7 +5,7 @@ import android.text.TextDirectionHeuristics
 import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress
 import java.util.Locale
 
-internal fun BillingAddress.summary(bidiFormatter: BidiFormatter = BidiFormatter.getInstance()): String {
+internal fun BillingAddress.summary(bidiFormatter: BidiFormatter): String {
     val strBuilder = StringBuilder()
 
     // Full name

--- a/frames/src/main/java/com/checkout/frames/utils/extensions/BillingAddressExtensions.kt
+++ b/frames/src/main/java/com/checkout/frames/utils/extensions/BillingAddressExtensions.kt
@@ -1,5 +1,7 @@
 package com.checkout.frames.utils.extensions
 
+import android.text.BidiFormatter
+import android.text.TextDirectionHeuristics
 import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress
 import java.util.Locale
 
@@ -23,13 +25,13 @@ internal fun BillingAddress.summary(): String {
     // Phone
     this.phone?.let { phone ->
         if (phone.number.isNotEmpty()) {
-            strBuilder.append(
-                if (phone.country?.dialingCode?.isNotEmpty() == true) {
-                    "\n+${phone.country?.dialingCode} ${phone.number}"
-                } else {
-                    "\n${phone.number}"
-                },
-            )
+            val bidiFormatter = BidiFormatter.getInstance()
+            val phoneText = if (phone.country?.dialingCode?.isNotEmpty() == true) {
+                bidiFormatter.unicodeWrap("+${phone.country?.dialingCode} ${phone.number}", TextDirectionHeuristics.LTR)
+            } else {
+                bidiFormatter.unicodeWrap(phone.number, TextDirectionHeuristics.LTR)
+            }
+            strBuilder.append("\n$phoneText")
         }
     }
 

--- a/frames/src/test/java/com/checkout/frames/component/addresssummary/AddressSummaryViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/component/addresssummary/AddressSummaryViewModelTest.kt
@@ -1,6 +1,8 @@
 package com.checkout.frames.component.addresssummary
 
 import android.annotation.SuppressLint
+import android.text.BidiFormatter
+import android.text.TextDirectionHeuristics
 import com.checkout.base.mapper.Mapper
 import com.checkout.base.model.Country
 import com.checkout.frames.mapper.BillingFormAddressToBillingAddressMapper
@@ -25,8 +27,10 @@ import com.checkout.frames.style.view.InternalButtonViewStyle
 import com.checkout.frames.style.view.addresssummary.AddressSummaryComponentViewStyle
 import com.checkout.tokenization.model.Address
 import com.checkout.tokenization.model.Phone
+import io.mockk.every
 import io.mockk.impl.annotations.SpyK
 import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -45,6 +49,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 @SuppressLint("NewApi")
 @ExtendWith(MockKExtension::class)
 internal class AddressSummaryViewModelTest {
+
+    private val bidiFormatter: BidiFormatter = mockk()
 
     @SpyK
     private lateinit var spyBillingFormAddressToBillingAddressMapper: Mapper<BillingFormAddress?, BillingAddress>
@@ -125,11 +131,12 @@ internal class AddressSummaryViewModelTest {
             ),
             phone = Phone("123", country),
         )
+        every { bidiFormatter.unicodeWrap(any(), TextDirectionHeuristics.LTR) } returns "+44 123"
         val expectedAddressPreview = "LINE 1\nLINE 2\nssdfsdf\nUnited Kingdom\n+44 123"
         spyPaymentStateManager.billingAddress.value = testAddress
 
         // When
-        viewModel.prepare()
+        viewModel.prepare(bidiFormatter)
         testScheduler.advanceUntilIdle()
 
         // Then
@@ -145,7 +152,7 @@ internal class AddressSummaryViewModelTest {
         spyPaymentStateManager.isBillingAddressEnabled.value = false
 
         // When
-        viewModel.prepare()
+        viewModel.prepare(bidiFormatter)
         testScheduler.advanceUntilIdle()
 
         // Then

--- a/frames/src/test/java/com/checkout/frames/utils/extensions/BillingAddressExtensionsTest.kt
+++ b/frames/src/test/java/com/checkout/frames/utils/extensions/BillingAddressExtensionsTest.kt
@@ -8,7 +8,6 @@ import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.Bi
 import com.checkout.tokenization.model.Address
 import com.checkout.tokenization.model.Phone
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import org.amshove.kluent.internal.assertEquals

--- a/frames/src/test/java/com/checkout/frames/utils/extensions/BillingAddressExtensionsTest.kt
+++ b/frames/src/test/java/com/checkout/frames/utils/extensions/BillingAddressExtensionsTest.kt
@@ -1,11 +1,16 @@
 package com.checkout.frames.utils.extensions
 
 import android.annotation.SuppressLint
+import android.text.BidiFormatter
+import android.text.TextDirectionHeuristics
 import com.checkout.base.model.Country
 import com.checkout.frames.screen.billingaddress.billingaddressdetails.models.BillingAddress
 import com.checkout.tokenization.model.Address
 import com.checkout.tokenization.model.Phone
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
 import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
@@ -17,6 +22,8 @@ import java.util.stream.Stream
 @ExtendWith(MockKExtension::class)
 internal class BillingAddressExtensionsTest {
 
+    private val bidiFormatter: BidiFormatter = mockk()
+
     @ParameterizedTest(
         name = "When summary of billing address {0} is requested then addressPreview {1} is provided",
     )
@@ -26,7 +33,8 @@ internal class BillingAddressExtensionsTest {
         expectedAddressPreview: String,
     ) {
         // When
-        val result = billingAddress.summary()
+        every { bidiFormatter.unicodeWrap(any(), TextDirectionHeuristics.LTR) } returns "+44 123"
+        val result = billingAddress.summary(bidiFormatter)
 
         // Then
         assertEquals(expectedAddressPreview, result)


### PR DESCRIPTION
## Issue

PIMOB-2639

## Proposed changes

Added BidiFormatter to handle RTL languages for phone number

## Test Steps
BEFORE THE FIX

https://github.com/checkout/frames-android/assets/123394131/a69bb19b-c8c4-40b0-b672-b4c7c57e7168

1. Open the sample app with the prefillData (as per requirement)
2. Open the device settings and set the device Language to any RTL language (in the video above is Arabic)
3. Reopen the app and verify that the phone is displayed correctly

AFTER THE FIX

https://github.com/checkout/frames-android/assets/123394131/2c54a7b2-146e-4556-ac07-db3cf5ce1443


## Checklist

* [x] Reviewers assigned
* [x] I have performed a self-review of my code and manual testing
* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)

