### PR TITLE
feature/PIMOB-3432_Remove_usage_of_action/checkoutv3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
         with:
           submodules: recursive
           

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,12 +37,12 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           submodules: recursive
           
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -52,7 +52,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Cache Gradle and wrapper
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f
         with:
           path: |
             ~/.gradle/caches
@@ -60,7 +60,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
@@ -69,4 +69,4 @@ jobs:
         run: ./gradlew :app:build
   
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88

--- a/.github/workflows/gradle-task.yml
+++ b/.github/workflows/gradle-task.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -37,7 +37,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Cache Gradle and wrapper
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f
         with:
           path: |
             ~/.gradle/caches
@@ -58,7 +58,7 @@ jobs:
       # Noted For Output [main_project_module]/build/outputs/apk/debug/
       - name: Upload APK Debug - ${{ env.repository_name }}
         if: ${{ inputs.push-apk }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ${{ env.date_today }} - ${{ env.repository_name }} - APK(s) debug generated
           path: ${{ inputs.module }}/build/outputs/apk/debug/
@@ -66,7 +66,7 @@ jobs:
       # Noted For Output [main_project_module]/build/outputs/apk/release/
       - name: Upload APK Release - ${{ env.repository_name }}
         if: ${{ inputs.push-apk }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ${{ env.date_today }} - ${{ env.repository_name }} - APK(s) release generated
           path: ${{ inputs.module }}/build/outputs/apk/release/

--- a/.github/workflows/gradle-task.yml
+++ b/.github/workflows/gradle-task.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/gradle-task.yml
+++ b/.github/workflows/gradle-task.yml
@@ -58,7 +58,7 @@ jobs:
       # Noted For Output [main_project_module]/build/outputs/apk/debug/
       - name: Upload APK Debug - ${{ env.repository_name }}
         if: ${{ inputs.push-apk }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.date_today }} - ${{ env.repository_name }} - APK(s) debug generated
           path: ${{ inputs.module }}/build/outputs/apk/debug/
@@ -66,7 +66,7 @@ jobs:
       # Noted For Output [main_project_module]/build/outputs/apk/release/
       - name: Upload APK Release - ${{ env.repository_name }}
         if: ${{ inputs.push-apk }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.date_today }} - ${{ env.repository_name }} - APK(s) release generated
           path: ${{ inputs.module }}/build/outputs/apk/release/

--- a/.github/workflows/slack-build-result.yml
+++ b/.github/workflows/slack-build-result.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slack Build Result
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/sonar-cloud-analysis.yml
+++ b/.github/workflows/sonar-cloud-analysis.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -43,7 +43,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Cache Gradle and wrapper
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f
         with:
           path: |
             ~/.gradle/caches
@@ -60,7 +60,7 @@ jobs:
         run: ./gradlew :frames:jacocoTestReport
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar-cloud-analysis.yml
+++ b/.github/workflows/sonar-cloud-analysis.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -34,7 +34,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Cache Gradle and wrapper
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
## Issue

PIMOB-3432

## Proposed changes

- Updating each action with the commit hash
- Updating the upload-artifact action 

## Test Steps

No test step

## Checklist

* [x] Reviewers assigned
* [x] I have performed a self-review of my code and manual testing
* [x] Lint and unit tests pass locally with my changes

## FAQ
- it is possible to instead have those hash has constant file?

No, GitHub Actions doesn't currently support "constants files" or global variable imports across multiple workflow files natively

- Shouldn't we have those hash as env var in our repo settings?

Possibly yes, this is a suitable approach but in the future.
Me and Okhan will, after this and the iOS PR, crosscheck if there are similarity in version used then unify them in the project settings
