### PR TITLE
PIMOB-3506: Update Risk SDK version to 2.1.0

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -36,7 +36,7 @@ object Versions {
     const val moshi = "1.15.1"
 
     // Risk SDK Dependencies
-    const val riskSdk = "2.0.0"
+    const val riskSdk = "2.1.0"
 
     // Unit Testing Dependencies
     const val junit5Jupiter = "5.8.0"

--- a/example_app_frames/lint-baseline.xml
+++ b/example_app_frames/lint-baseline.xml
@@ -5,21 +5,21 @@
         id="ObsoleteLintCustomCheck"
         message="Library lint checks reference invalid APIs; these checks **will be skipped**!&#xA;&#xA;Lint found an issue registry (`androidx.compose.runtime.lint.RuntimeIssueRegistry`)&#xA;which contains some references to invalid API:&#xA;org.jetbrains.kotlin.analysis.api.session.KtAnalysisSessionProvider: org.jetbrains.kotlin.analysis.api.lifetime.KtLifetimeTokenFactory getTokenFactory()&#xA;(Referenced from androidx/compose/runtime/lint/AutoboxingStateCreationDetector.class)&#xA;&#xA;Therefore, this lint check library is **not** included&#xA;in analysis. This affects the following lint checks:&#xA;`AutoboxingStateValueProperty`&#xA;`AutoboxingStateCreation`&#xA;`CoroutineCreationDuringComposition`&#xA;`FlowOperatorInvokedInComposition`&#xA;`ComposableLambdaParameterNaming`&#xA;`ComposableLambdaParameterPosition`&#xA;`ComposableNaming`&#xA;`StateFlowValueCalledInComposition`&#xA;`CompositionLocalNaming`&#xA;`MutableCollectionMutableState`&#xA;`ProduceStateDoesNotAssignValue`&#xA;`RememberReturnType`&#xA;`OpaqueUnitKey`&#xA;`UnrememberedMutableState`&#xA;&#xA;To use this lint check, upgrade to a more recent version&#xA;of the library.">
         <location
-            file="$GRADLE_USER_HOME/caches/transforms-3/5d60756753ac588eed05a99c575185c1/transformed/jetified-runtime-release/jars/lint.jar"/>
+            file="$GRADLE_USER_HOME/caches/transforms-3/ee5105f07541a5ac3b90afacf4ec7f34/transformed/jetified-runtime-release/jars/lint.jar"/>
     </issue>
 
     <issue
         id="ObsoleteLintCustomCheck"
         message="Library lint checks reference invalid APIs; these checks **will be skipped**!&#xA;&#xA;Lint found an issue registry (`androidx.compose.ui.lint.UiIssueRegistry`)&#xA;which contains some references to invalid API:&#xA;org.jetbrains.kotlin.analysis.api.session.KtAnalysisSessionProvider: org.jetbrains.kotlin.analysis.api.lifetime.KtLifetimeTokenFactory getTokenFactory()&#xA;(Referenced from androidx/compose/ui/lint/ModifierDeclarationDetectorKt$ensureReceiverIsReferenced$1.class)&#xA;&#xA;Therefore, this lint check library is **not** included&#xA;in analysis. This affects the following lint checks:&#xA;`UnnecessaryComposedModifier`&#xA;`ModifierFactoryExtensionFunction`&#xA;`ModifierFactoryReturnType`&#xA;`ModifierFactoryUnreferencedReceiver`&#xA;`ModifierNodeInspectableProperties`&#xA;`ModifierParameter`&#xA;`MultipleAwaitPointerEventScopes`&#xA;`ReturnFromAwaitPointerEventScope`&#xA;`SuspiciousCompositionLocalModifierRead`&#xA;`SuspiciousModifierThen`&#xA;&#xA;To use this lint check, upgrade to a more recent version&#xA;of the library.">
         <location
-            file="$GRADLE_USER_HOME/caches/transforms-3/11e0c50f7294f8015ba7d62a877bed79/transformed/jetified-ui-release/jars/lint.jar"/>
+            file="$GRADLE_USER_HOME/caches/transforms-3/b4bde755a4a8b7197099d0e7b13dc849/transformed/jetified-ui-release/jars/lint.jar"/>
     </issue>
 
     <issue
         id="ObsoleteLintCustomCheck"
         message="Library lint checks reference invalid APIs; these checks **will be skipped**!&#xA;&#xA;Lint found an issue registry (`androidx.lifecycle.lint.LiveDataCoreIssueRegistry`)&#xA;which contains some references to invalid API:&#xA;org.jetbrains.kotlin.analysis.api.session.KtAnalysisSessionProvider: org.jetbrains.kotlin.analysis.api.lifetime.KtLifetimeTokenFactory getTokenFactory()&#xA;(Referenced from androidx/lifecycle/lint/NonNullableMutableLiveDataDetector$createUastHandler$1.class)&#xA;&#xA;Therefore, this lint check library is **not** included&#xA;in analysis. This affects the following lint checks:&#xA;`NullSafeMutableLiveData`&#xA;&#xA;To use this lint check, upgrade to a more recent version&#xA;of the library.">
         <location
-            file="$GRADLE_USER_HOME/caches/transforms-3/d0c6f2ac58801b6741ccaab8c40fd602/transformed/lifecycle-livedata-core-2.8.3/jars/lint.jar"/>
+            file="$GRADLE_USER_HOME/caches/transforms-3/3e6f8b77e19489f3b3351ee3499e8d15/transformed/lifecycle-livedata-core-2.8.3/jars/lint.jar"/>
     </issue>
 
     <issue

--- a/frames/lint-baseline.xml
+++ b/frames/lint-baseline.xml
@@ -5,21 +5,21 @@
         id="ObsoleteLintCustomCheck"
         message="Library lint checks reference invalid APIs; these checks **will be skipped**!&#xA;&#xA;Lint found an issue registry (`androidx.compose.runtime.lint.RuntimeIssueRegistry`)&#xA;which contains some references to invalid API:&#xA;org.jetbrains.kotlin.analysis.api.session.KtAnalysisSessionProvider: org.jetbrains.kotlin.analysis.api.lifetime.KtLifetimeTokenFactory getTokenFactory()&#xA;(Referenced from androidx/compose/runtime/lint/AutoboxingStateCreationDetector.class)&#xA;&#xA;Therefore, this lint check library is **not** included&#xA;in analysis. This affects the following lint checks:&#xA;`AutoboxingStateValueProperty`&#xA;`AutoboxingStateCreation`&#xA;`CoroutineCreationDuringComposition`&#xA;`FlowOperatorInvokedInComposition`&#xA;`ComposableLambdaParameterNaming`&#xA;`ComposableLambdaParameterPosition`&#xA;`ComposableNaming`&#xA;`StateFlowValueCalledInComposition`&#xA;`CompositionLocalNaming`&#xA;`MutableCollectionMutableState`&#xA;`ProduceStateDoesNotAssignValue`&#xA;`RememberReturnType`&#xA;`OpaqueUnitKey`&#xA;`UnrememberedMutableState`&#xA;&#xA;To use this lint check, upgrade to a more recent version&#xA;of the library.">
         <location
-            file="$GRADLE_USER_HOME/caches/transforms-3/5d60756753ac588eed05a99c575185c1/transformed/jetified-runtime-release/jars/lint.jar"/>
+            file="$GRADLE_USER_HOME/caches/transforms-3/ee5105f07541a5ac3b90afacf4ec7f34/transformed/jetified-runtime-release/jars/lint.jar"/>
     </issue>
 
     <issue
         id="ObsoleteLintCustomCheck"
         message="Library lint checks reference invalid APIs; these checks **will be skipped**!&#xA;&#xA;Lint found an issue registry (`androidx.compose.ui.lint.UiIssueRegistry`)&#xA;which contains some references to invalid API:&#xA;org.jetbrains.kotlin.analysis.api.session.KtAnalysisSessionProvider: org.jetbrains.kotlin.analysis.api.lifetime.KtLifetimeTokenFactory getTokenFactory()&#xA;(Referenced from androidx/compose/ui/lint/ModifierDeclarationDetectorKt$ensureReceiverIsReferenced$1.class)&#xA;&#xA;Therefore, this lint check library is **not** included&#xA;in analysis. This affects the following lint checks:&#xA;`UnnecessaryComposedModifier`&#xA;`ModifierFactoryExtensionFunction`&#xA;`ModifierFactoryReturnType`&#xA;`ModifierFactoryUnreferencedReceiver`&#xA;`ModifierNodeInspectableProperties`&#xA;`ModifierParameter`&#xA;`MultipleAwaitPointerEventScopes`&#xA;`ReturnFromAwaitPointerEventScope`&#xA;`SuspiciousCompositionLocalModifierRead`&#xA;`SuspiciousModifierThen`&#xA;&#xA;To use this lint check, upgrade to a more recent version&#xA;of the library.">
         <location
-            file="$GRADLE_USER_HOME/caches/transforms-3/11e0c50f7294f8015ba7d62a877bed79/transformed/jetified-ui-release/jars/lint.jar"/>
+            file="$GRADLE_USER_HOME/caches/transforms-3/b4bde755a4a8b7197099d0e7b13dc849/transformed/jetified-ui-release/jars/lint.jar"/>
     </issue>
 
     <issue
         id="ObsoleteLintCustomCheck"
         message="Library lint checks reference invalid APIs; these checks **will be skipped**!&#xA;&#xA;Lint found an issue registry (`androidx.lifecycle.lint.LiveDataCoreIssueRegistry`)&#xA;which contains some references to invalid API:&#xA;org.jetbrains.kotlin.analysis.api.session.KtAnalysisSessionProvider: org.jetbrains.kotlin.analysis.api.lifetime.KtLifetimeTokenFactory getTokenFactory()&#xA;(Referenced from androidx/lifecycle/lint/NonNullableMutableLiveDataDetector$createUastHandler$1.class)&#xA;&#xA;Therefore, this lint check library is **not** included&#xA;in analysis. This affects the following lint checks:&#xA;`NullSafeMutableLiveData`&#xA;&#xA;To use this lint check, upgrade to a more recent version&#xA;of the library.">
         <location
-            file="$GRADLE_USER_HOME/caches/transforms-3/d0c6f2ac58801b6741ccaab8c40fd602/transformed/lifecycle-livedata-core-2.8.3/jars/lint.jar"/>
+            file="$GRADLE_USER_HOME/caches/transforms-3/3e6f8b77e19489f3b3351ee3499e8d15/transformed/lifecycle-livedata-core-2.8.3/jars/lint.jar"/>
     </issue>
 
 </issues>


### PR DESCRIPTION
## Issue

PIMOB-3506

## Proposed changes

Update Risk SDK version to `2.1.0`

## Test Steps

No functionality change, it's required to support the latest fingerprint pro version

## Checklist

* [x] Reviewers assigned
* [x] I have performed a self-review of my code and manual testing
