### PR TITLE
[PIMOB-4287]: adding base url prefix to Frames SDK for multi-region

### DIFF
--- a/.github/workflows/gradle-task.yml
+++ b/.github/workflows/gradle-task.yml
@@ -43,6 +43,13 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+
+      - name: Create local.properties
+        run: |
+            touch local.properties
+            echo "sandbox.components.public_key=${{ secrets.COMPONENTS_SANDBOX_PUBLIC_KEY }}" >> local.properties
+            echo "sandbox.components.secret_key=${{ secrets.COMPONENTS_SANDBOX_SECRET_KEY }}" >> local.properties
+
       - name: Run ${{ inputs.task }} with Gradle
         run: ./gradlew :${{ inputs.module }}:${{ inputs.task }}
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,21 @@ android {
     lint {
         baseline = file('lint-baseline.xml')
     }
+
+    def localProps = new Properties()
+    def localPropsFile = rootProject.file("local.properties")
+    if (localPropsFile.exists()) {
+        localPropsFile.withInputStream { localProps.load(it) }
+    }
+
+    defaultConfig {
+        buildConfigField("String", "SANDBOX_PUBLIC_KEY", "${localProps.getProperty("sandbox.components.public_key") ?: ""}")
+        buildConfigField("String", "SANDBOX_SECRET_KEY", "${localProps.getProperty("sandbox.components.secret_key") ?: ""}")
+        buildConfigField("String", "SANDBOX_PROCESSING_CHANNEL_ID", "${localProps.getProperty("sandbox.components.processing_channel_id") ?: ""}")
+    }
+    buildFeatures {
+        buildConfig true
+    }
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,16 +49,17 @@ android {
     def localProps = new Properties()
     def localPropsFile = rootProject.file("local.properties")
     if (localPropsFile.exists()) {
-        localPropsFile.withInputStream { localProps.load(it) }
+        localProps.load(localPropsFile.newDataInputStream())
     }
 
     defaultConfig {
-        buildConfigField("String", "SANDBOX_PUBLIC_KEY", "${localProps.getProperty("sandbox.components.public_key") ?: ""}")
-        buildConfigField("String", "SANDBOX_SECRET_KEY", "${localProps.getProperty("sandbox.components.secret_key") ?: ""}")
-        buildConfigField("String", "SANDBOX_PROCESSING_CHANNEL_ID", "${localProps.getProperty("sandbox.components.processing_channel_id") ?: ""}")
-    }
-    buildFeatures {
-        buildConfig true
+        buildConfigField "String", "SANDBOX_PUBLIC_KEY", "\"${localProps.getProperty("sandbox.components.public_key") ?: ""}\""
+        buildConfigField "String", "SANDBOX_SECRET_KEY", "\"${localProps.getProperty("sandbox.components.secret_key") ?: ""}\""
+        buildConfigField "String", "SANDBOX_PROCESSING_CHANNEL_ID", "\"${localProps.getProperty("sandbox.components.processing_channel_id") ?: ""}\""
+
+        buildFeatures {
+            buildConfig true
+        }
     }
 }
 

--- a/app/src/main/java/checkout/checkout_android/CVVTokenizationActivity.java
+++ b/app/src/main/java/checkout/checkout_android/CVVTokenizationActivity.java
@@ -1,6 +1,5 @@
 package checkout.checkout_android;
 
-import static checkout.checkout_android.Constants.PUBLIC_KEY_CVV_TOKENIZATION;
 import static checkout.checkout_android.Constants.REGIONAL_SUBDOMAIN;
 
 import android.app.AlertDialog;
@@ -52,7 +51,7 @@ public class CVVTokenizationActivity extends ComponentActivity {
 		setupObservers();
 
 		// Create cvvComponentApi
-		CVVComponentApi cvvComponentApi = CVVComponentApiFactory.create(PUBLIC_KEY_CVV_TOKENIZATION, Environment.SANDBOX, this, REGIONAL_SUBDOMAIN);
+		CVVComponentApi cvvComponentApi = CVVComponentApiFactory.create(BuildConfig.SANDBOX_PUBLIC_KEY, Environment.SANDBOX, this, REGIONAL_SUBDOMAIN);
 
 		// initialise CVVTokenizationResultHandler for tokenization
 		resultHandler = result -> {

--- a/app/src/main/java/checkout/checkout_android/CVVTokenizationActivity.java
+++ b/app/src/main/java/checkout/checkout_android/CVVTokenizationActivity.java
@@ -1,6 +1,7 @@
 package checkout.checkout_android;
 
 import static checkout.checkout_android.Constants.PUBLIC_KEY_CVV_TOKENIZATION;
+import static checkout.checkout_android.Constants.REGIONAL_SUBDOMAIN;
 
 import android.app.AlertDialog;
 import android.os.Bundle;
@@ -51,7 +52,7 @@ public class CVVTokenizationActivity extends ComponentActivity {
 		setupObservers();
 
 		// Create cvvComponentApi
-		CVVComponentApi cvvComponentApi = CVVComponentApiFactory.create(PUBLIC_KEY_CVV_TOKENIZATION, Environment.SANDBOX, this);
+		CVVComponentApi cvvComponentApi = CVVComponentApiFactory.create(PUBLIC_KEY_CVV_TOKENIZATION, Environment.SANDBOX, this, REGIONAL_SUBDOMAIN);
 
 		// initialise CVVTokenizationResultHandler for tokenization
 		resultHandler = result -> {

--- a/app/src/main/java/checkout/checkout_android/Constants.java
+++ b/app/src/main/java/checkout/checkout_android/Constants.java
@@ -10,16 +10,20 @@ public class Constants {
 	/**
 	 * Replace with public key from Hub in Sandbox Environment
 	 */
-	public static final String PUBLIC_KEY = "pk_test_b37b8b6b-fc9a-483f-a77e-3386b606f90e";
+	public static final String PUBLIC_KEY = "pk_sbox_dheqoi7tqn2jcvbn55sa2czwu42";
 
 	/**
 	 * Replace with public key from Hub in Sandbox Environment, testing key for CVV Tokenization
 	 */
-	public static final String PUBLIC_KEY_CVV_TOKENIZATION = "pk_6b30805a-1f3b-4c63-8b75-eb3030109173";
+	public static final String PUBLIC_KEY_CVV_TOKENIZATION = "pk_sbox_dheqoi7tqn2jcvbn55sa2czwu42";
 	/**
 	 * Replace with Secret key from Hub in Sandbox Environment
 	 */
-	public static final String SECRET_KEY = "sk_test_568e6077-a08f-4692-9237-cc6c48dcf6aa";
+	public static final String SECRET_KEY = "sk_sbox_cqc26o3haljkwuns6xcfcmf2vmu";
+    /**
+     * Replace with subdomain value, testing key for base url regional subdomain prefix
+     */
+    public static final  String REGIONAL_SUBDOMAIN = "global";
 	/**
 	 * Replace with Success/Failure Urls from Hub in Sandbox Environment
 	 */

--- a/app/src/main/java/checkout/checkout_android/Constants.java
+++ b/app/src/main/java/checkout/checkout_android/Constants.java
@@ -7,19 +7,7 @@ public class Constants {
 	 * Target platform environment
 	 */
 	public static final Environment ENVIRONMENT = Environment.SANDBOX;
-	/**
-	 * Replace with public key from Hub in Sandbox Environment
-	 */
-	public static final String PUBLIC_KEY = "pk_sbox_dheqoi7tqn2jcvbn55sa2czwu42";
 
-	/**
-	 * Replace with public key from Hub in Sandbox Environment, testing key for CVV Tokenization
-	 */
-	public static final String PUBLIC_KEY_CVV_TOKENIZATION = "pk_sbox_dheqoi7tqn2jcvbn55sa2czwu42";
-	/**
-	 * Replace with Secret key from Hub in Sandbox Environment
-	 */
-	public static final String SECRET_KEY = "sk_sbox_cqc26o3haljkwuns6xcfcmf2vmu";
     /**
      * Replace with subdomain value, testing key for base url regional subdomain prefix
      */

--- a/app/src/main/java/checkout/checkout_android/DemoActivity.java
+++ b/app/src/main/java/checkout/checkout_android/DemoActivity.java
@@ -1,5 +1,7 @@
 package checkout.checkout_android;
 
+import static checkout.checkout_android.Constants.REGIONAL_SUBDOMAIN;
+
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.os.Bundle;
@@ -17,6 +19,8 @@ import com.checkout.frames.style.screen.PaymentFormStyle;
 import com.checkout.threedsecure.model.ThreeDSRequest;
 import com.checkout.threedsecure.model.ThreeDSResult;
 import com.checkout.tokenization.model.TokenDetails;
+
+import java.util.Collections;
 
 import checkout.checkout_android.utils.PaymentUtil;
 import kotlin.Unit;
@@ -93,7 +97,11 @@ public class DemoActivity extends ComponentActivity {
                 this,
                 Constants.ENVIRONMENT,
                 new PaymentFormStyle(),
-                mPaymentFlowHandler);
+                mPaymentFlowHandler,
+                Collections.emptyList(),
+                null,
+                REGIONAL_SUBDOMAIN
+        );
     }
 
     private void displayMessage(String title, String message, boolean exitScreen) {

--- a/app/src/main/java/checkout/checkout_android/DemoActivity.java
+++ b/app/src/main/java/checkout/checkout_android/DemoActivity.java
@@ -93,7 +93,7 @@ public class DemoActivity extends ComponentActivity {
 
     private PaymentFormConfig providePaymentFormConfig() {
         return new PaymentFormConfig(
-                Constants.PUBLIC_KEY,
+                BuildConfig.SANDBOX_PUBLIC_KEY,
                 this,
                 Constants.ENVIRONMENT,
                 new PaymentFormStyle(),

--- a/app/src/main/java/checkout/checkout_android/utils/PaymentUtil.java
+++ b/app/src/main/java/checkout/checkout_android/utils/PaymentUtil.java
@@ -11,6 +11,7 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 
+import checkout.checkout_android.BuildConfig;
 import checkout.checkout_android.Constants;
 import okhttp3.Call;
 import okhttp3.MediaType;
@@ -47,7 +48,7 @@ public class PaymentUtil {
         RequestBody requestBody = buildPaymentRequestBody(token);
         Request paymentRequest = new Request.Builder()
                 .url("https://api.sandbox.checkout.com/payments")
-                .addHeader("Authorization", "Bearer "+Constants.SECRET_KEY)
+                .addHeader("Authorization", "Bearer "+ BuildConfig.SANDBOX_SECRET_KEY)
                 .post(requestBody)
                 .build();
 

--- a/checkout/src/main/java/com/checkout/CheckoutApiServiceFactory.kt
+++ b/checkout/src/main/java/com/checkout/CheckoutApiServiceFactory.kt
@@ -41,7 +41,7 @@ public object CheckoutApiServiceFactory {
         publicKey: String,
         environment: Environment,
         context: Context,
-        baseUrlPrefix: String?
+        baseUrlPrefix: String? = null,
     ): CheckoutApiService {
         val logger = EventLoggerProvider.provide()
         logger.setup(context, environment)
@@ -62,8 +62,8 @@ public object CheckoutApiServiceFactory {
         context: Context,
         publicKey: String,
         environment: Environment,
-        baseUrlPrefix: String?
-    ): TokenRepository  {
+        baseUrlPrefix: String?,
+    ): TokenRepository {
         return TokenRepositoryImpl(
             networkApiClient = provideNetworkApiClient(publicKey, environment.toBaseUrl(baseUrlPrefix)),
             cardToTokenRequestMapper = CardToTokenRequestMapper(),
@@ -86,7 +86,7 @@ public object CheckoutApiServiceFactory {
                 context,
                 publicKey,
                 riskSDKFramesOptions,
-                RiskInstanceProvider
+                RiskInstanceProvider,
             ),
         )
     }

--- a/checkout/src/main/java/com/checkout/CheckoutApiServiceFactory.kt
+++ b/checkout/src/main/java/com/checkout/CheckoutApiServiceFactory.kt
@@ -7,6 +7,7 @@ import com.checkout.base.model.Environment
 import com.checkout.logging.EventLoggerProvider
 import com.checkout.logging.Logger
 import com.checkout.logging.model.LoggingEvent
+import com.checkout.logging.utils.toBaseUrl
 import com.checkout.network.OkHttpProvider
 import com.checkout.risk.FramesOptions
 import com.checkout.threedsecure.Executor
@@ -40,6 +41,7 @@ public object CheckoutApiServiceFactory {
         publicKey: String,
         environment: Environment,
         context: Context,
+        regionalSubdomain: String?
     ): CheckoutApiService {
         val logger = EventLoggerProvider.provide()
         logger.setup(context, environment)
@@ -51,7 +53,7 @@ public object CheckoutApiServiceFactory {
         )
 
         return CheckoutApiClient(
-            provideTokenRepository(context, publicKey, environment),
+            provideTokenRepository(context, publicKey, environment, regionalSubdomain),
             provideThreeDSExecutor(logger),
         )
     }
@@ -60,25 +62,34 @@ public object CheckoutApiServiceFactory {
         context: Context,
         publicKey: String,
         environment: Environment,
-    ): TokenRepository = TokenRepositoryImpl(
-        networkApiClient = provideNetworkApiClient(publicKey, environment.url),
-        cardToTokenRequestMapper = CardToTokenRequestMapper(),
-        cvvToTokenNetworkRequestMapper = CVVToTokenNetworkRequestMapper(),
-        cardTokenizationNetworkDataMapper = CardTokenizationNetworkDataMapper(),
-        validateTokenizationDataUseCase = ValidateTokenizationDataUseCase(
-            CardValidatorFactory.createInternal(),
-            AddressValidator(),
-            PhoneValidator(),
-            AddressToAddressValidationRequestDataMapper(),
-        ),
-        validateCVVTokenizationDataUseCase = ValidateCVVTokenizationDataUseCase(
-            CVVComponentValidatorFactory.create(),
-        ),
-        logger = TokenizationEventLogger(EventLoggerProvider.provide()),
-        publicKey = publicKey,
-        cvvTokenizationNetworkDataMapper = CVVTokenizationNetworkDataMapper(),
-        riskSdkUseCase = RiskSdkUseCase(environment, context, publicKey, riskSDKFramesOptions, RiskInstanceProvider),
-    )
+        regionalSubdomain: String?
+    ): TokenRepository  {
+        return TokenRepositoryImpl(
+            networkApiClient = provideNetworkApiClient(publicKey, environment.toBaseUrl(regionalSubdomain)),
+            cardToTokenRequestMapper = CardToTokenRequestMapper(),
+            cvvToTokenNetworkRequestMapper = CVVToTokenNetworkRequestMapper(),
+            cardTokenizationNetworkDataMapper = CardTokenizationNetworkDataMapper(),
+            validateTokenizationDataUseCase = ValidateTokenizationDataUseCase(
+                CardValidatorFactory.createInternal(),
+                AddressValidator(),
+                PhoneValidator(),
+                AddressToAddressValidationRequestDataMapper(),
+            ),
+            validateCVVTokenizationDataUseCase = ValidateCVVTokenizationDataUseCase(
+                CVVComponentValidatorFactory.create(),
+            ),
+            logger = TokenizationEventLogger(EventLoggerProvider.provide()),
+            publicKey = publicKey,
+            cvvTokenizationNetworkDataMapper = CVVTokenizationNetworkDataMapper(),
+            riskSdkUseCase = RiskSdkUseCase(
+                environment,
+                context,
+                publicKey,
+                riskSDKFramesOptions,
+                RiskInstanceProvider
+            ),
+        )
+    }
 
     private fun provideNetworkApiClient(
         publicKey: String,

--- a/checkout/src/main/java/com/checkout/CheckoutApiServiceFactory.kt
+++ b/checkout/src/main/java/com/checkout/CheckoutApiServiceFactory.kt
@@ -63,33 +63,31 @@ public object CheckoutApiServiceFactory {
         publicKey: String,
         environment: Environment,
         baseUrlPrefix: String?,
-    ): TokenRepository {
-        return TokenRepositoryImpl(
-            networkApiClient = provideNetworkApiClient(publicKey, environment.toBaseUrl(baseUrlPrefix)),
-            cardToTokenRequestMapper = CardToTokenRequestMapper(),
-            cvvToTokenNetworkRequestMapper = CVVToTokenNetworkRequestMapper(),
-            cardTokenizationNetworkDataMapper = CardTokenizationNetworkDataMapper(),
-            validateTokenizationDataUseCase = ValidateTokenizationDataUseCase(
-                CardValidatorFactory.createInternal(),
-                AddressValidator(),
-                PhoneValidator(),
-                AddressToAddressValidationRequestDataMapper(),
-            ),
-            validateCVVTokenizationDataUseCase = ValidateCVVTokenizationDataUseCase(
-                CVVComponentValidatorFactory.create(),
-            ),
-            logger = TokenizationEventLogger(EventLoggerProvider.provide()),
-            publicKey = publicKey,
-            cvvTokenizationNetworkDataMapper = CVVTokenizationNetworkDataMapper(),
-            riskSdkUseCase = RiskSdkUseCase(
-                environment,
-                context,
-                publicKey,
-                riskSDKFramesOptions,
-                RiskInstanceProvider,
-            ),
-        )
-    }
+    ): TokenRepository = TokenRepositoryImpl(
+        networkApiClient = provideNetworkApiClient(publicKey, environment.toBaseUrl(baseUrlPrefix)),
+        cardToTokenRequestMapper = CardToTokenRequestMapper(),
+        cvvToTokenNetworkRequestMapper = CVVToTokenNetworkRequestMapper(),
+        cardTokenizationNetworkDataMapper = CardTokenizationNetworkDataMapper(),
+        validateTokenizationDataUseCase = ValidateTokenizationDataUseCase(
+            CardValidatorFactory.createInternal(),
+            AddressValidator(),
+            PhoneValidator(),
+            AddressToAddressValidationRequestDataMapper(),
+        ),
+        validateCVVTokenizationDataUseCase = ValidateCVVTokenizationDataUseCase(
+            CVVComponentValidatorFactory.create(),
+        ),
+        logger = TokenizationEventLogger(EventLoggerProvider.provide()),
+        publicKey = publicKey,
+        cvvTokenizationNetworkDataMapper = CVVTokenizationNetworkDataMapper(),
+        riskSdkUseCase = RiskSdkUseCase(
+            environment,
+            context,
+            publicKey,
+            riskSDKFramesOptions,
+            RiskInstanceProvider,
+        ),
+    )
 
     private fun provideNetworkApiClient(
         publicKey: String,

--- a/checkout/src/main/java/com/checkout/CheckoutApiServiceFactory.kt
+++ b/checkout/src/main/java/com/checkout/CheckoutApiServiceFactory.kt
@@ -41,7 +41,7 @@ public object CheckoutApiServiceFactory {
         publicKey: String,
         environment: Environment,
         context: Context,
-        baseURLPrefix: String?
+        baseUrlPrefix: String?
     ): CheckoutApiService {
         val logger = EventLoggerProvider.provide()
         logger.setup(context, environment)
@@ -53,7 +53,7 @@ public object CheckoutApiServiceFactory {
         )
 
         return CheckoutApiClient(
-            provideTokenRepository(context, publicKey, environment, baseURLPrefix),
+            provideTokenRepository(context, publicKey, environment, baseUrlPrefix),
             provideThreeDSExecutor(logger),
         )
     }
@@ -62,10 +62,10 @@ public object CheckoutApiServiceFactory {
         context: Context,
         publicKey: String,
         environment: Environment,
-        baseURLPrefix: String?
+        baseUrlPrefix: String?
     ): TokenRepository  {
         return TokenRepositoryImpl(
-            networkApiClient = provideNetworkApiClient(publicKey, environment.toBaseUrl(baseURLPrefix)),
+            networkApiClient = provideNetworkApiClient(publicKey, environment.toBaseUrl(baseUrlPrefix)),
             cardToTokenRequestMapper = CardToTokenRequestMapper(),
             cvvToTokenNetworkRequestMapper = CVVToTokenNetworkRequestMapper(),
             cardTokenizationNetworkDataMapper = CardTokenizationNetworkDataMapper(),

--- a/checkout/src/main/java/com/checkout/CheckoutApiServiceFactory.kt
+++ b/checkout/src/main/java/com/checkout/CheckoutApiServiceFactory.kt
@@ -41,7 +41,7 @@ public object CheckoutApiServiceFactory {
         publicKey: String,
         environment: Environment,
         context: Context,
-        regionalSubdomain: String?
+        baseURLPrefix: String?
     ): CheckoutApiService {
         val logger = EventLoggerProvider.provide()
         logger.setup(context, environment)
@@ -53,7 +53,7 @@ public object CheckoutApiServiceFactory {
         )
 
         return CheckoutApiClient(
-            provideTokenRepository(context, publicKey, environment, regionalSubdomain),
+            provideTokenRepository(context, publicKey, environment, baseURLPrefix),
             provideThreeDSExecutor(logger),
         )
     }
@@ -62,10 +62,10 @@ public object CheckoutApiServiceFactory {
         context: Context,
         publicKey: String,
         environment: Environment,
-        regionalSubdomain: String?
+        baseURLPrefix: String?
     ): TokenRepository  {
         return TokenRepositoryImpl(
-            networkApiClient = provideNetworkApiClient(publicKey, environment.toBaseUrl(regionalSubdomain)),
+            networkApiClient = provideNetworkApiClient(publicKey, environment.toBaseUrl(baseURLPrefix)),
             cardToTokenRequestMapper = CardToTokenRequestMapper(),
             cvvToTokenNetworkRequestMapper = CVVToTokenNetworkRequestMapper(),
             cardTokenizationNetworkDataMapper = CardTokenizationNetworkDataMapper(),

--- a/checkout/src/main/java/com/checkout/base/model/Environment.kt
+++ b/checkout/src/main/java/com/checkout/base/model/Environment.kt
@@ -1,8 +1,6 @@
 package com.checkout.base.model
 
-import com.checkout.base.util.EnvironmentConstants
-
-public enum class Environment(public val url: String) {
-    PRODUCTION(EnvironmentConstants.PRODUCTION_SERVER_URL),
-    SANDBOX(EnvironmentConstants.SANDBOX_SERVER_URL),
+public enum class Environment {
+    PRODUCTION,
+    SANDBOX
 }

--- a/checkout/src/main/java/com/checkout/base/model/Environment.kt
+++ b/checkout/src/main/java/com/checkout/base/model/Environment.kt
@@ -2,5 +2,5 @@ package com.checkout.base.model
 
 public enum class Environment {
     PRODUCTION,
-    SANDBOX
+    SANDBOX,
 }

--- a/checkout/src/main/java/com/checkout/base/util/CommonConstants.kt
+++ b/checkout/src/main/java/com/checkout/base/util/CommonConstants.kt
@@ -16,6 +16,6 @@ internal const val PHONE_MIN_LENGTH = 6
 internal const val PHONE_MAX_LENGTH = 25
 
 /**
- * Constants for environments
+ * Constant for HTTPS protocol prefix, used when constructing environments' base URLs for network communication.
  */
 internal const val HTTPS_PROTOCOL: String = "https://"

--- a/checkout/src/main/java/com/checkout/base/util/CommonConstants.kt
+++ b/checkout/src/main/java/com/checkout/base/util/CommonConstants.kt
@@ -14,3 +14,8 @@ internal const val ZIP_LENGTH = 50
  */
 internal const val PHONE_MIN_LENGTH = 6
 internal const val PHONE_MAX_LENGTH = 25
+
+/**
+ * Constants for environments
+ */
+internal const val HTTPS_PROTOCOL: String = "https://"

--- a/checkout/src/main/java/com/checkout/base/util/EnvironmentConstants.kt
+++ b/checkout/src/main/java/com/checkout/base/util/EnvironmentConstants.kt
@@ -3,4 +3,6 @@ package com.checkout.base.util
 internal object EnvironmentConstants {
     internal const val SANDBOX_SERVER_URL = "https://api.sandbox.checkout.com/tokens"
     internal const val PRODUCTION_SERVER_URL = "https://api.checkout.com/tokens"
+    internal const val PRODUCTION_LOGGING = "production"
+    internal const val SANDBOX_LOGGING = "sandbox"
 }

--- a/checkout/src/main/java/com/checkout/logging/utils/EnvironmentExtension.kt
+++ b/checkout/src/main/java/com/checkout/logging/utils/EnvironmentExtension.kt
@@ -4,13 +4,12 @@ import com.checkout.base.model.Environment
 import com.checkout.base.util.EnvironmentConstants.PRODUCTION_SERVER_URL
 import com.checkout.base.util.EnvironmentConstants.SANDBOX_SERVER_URL
 
-
-internal fun Environment.toBaseUrl(baseUrlPrefix: String? = null) = when(this) {
+internal fun Environment.toBaseUrl(baseUrlPrefix: String? = null) = when (this) {
     Environment.PRODUCTION -> baseUrlPrefix?.baseUrlPrefixValidator()?.let {
-        "https://${baseUrlPrefix}.api.checkout.com/tokens"
+        "https://$baseUrlPrefix.api.checkout.com/tokens"
     } ?: PRODUCTION_SERVER_URL
     Environment.SANDBOX -> baseUrlPrefix?.baseUrlPrefixValidator()?.let {
-        "https://${baseUrlPrefix}.api.sandbox.checkout.com/tokens"
+        "https://$baseUrlPrefix.api.sandbox.checkout.com/tokens"
     } ?: SANDBOX_SERVER_URL
 }
 internal fun Environment.toLoggingEnvironment() = when (this) {
@@ -19,10 +18,13 @@ internal fun Environment.toLoggingEnvironment() = when (this) {
 }
 
 internal fun Environment.toLoggingName() = when (this) {
-    Environment.PRODUCTION -> "production"
-    Environment.SANDBOX -> "sandbox"
+    Environment.PRODUCTION ->
+        "production"
+    Environment.SANDBOX ->
+        "sandbox"
 }
 
 private fun String?.baseUrlPrefixValidator() = this?.takeIf {
-    prefix -> prefix.all { char -> char.isLetterOrDigit() } && prefix.isNotEmpty()
+    prefix ->
+    prefix.all { char -> char.isLetterOrDigit() } && prefix.isNotEmpty()
 }

--- a/checkout/src/main/java/com/checkout/logging/utils/EnvironmentExtension.kt
+++ b/checkout/src/main/java/com/checkout/logging/utils/EnvironmentExtension.kt
@@ -1,16 +1,15 @@
 package com.checkout.logging.utils
 
 import com.checkout.base.model.Environment
+import com.checkout.base.util.EnvironmentConstants.PRODUCTION_LOGGING
 import com.checkout.base.util.EnvironmentConstants.PRODUCTION_SERVER_URL
+import com.checkout.base.util.EnvironmentConstants.SANDBOX_LOGGING
 import com.checkout.base.util.EnvironmentConstants.SANDBOX_SERVER_URL
+import com.checkout.base.util.HTTPS_PROTOCOL
 
 internal fun Environment.toBaseUrl(baseUrlPrefix: String? = null) = when (this) {
-    Environment.PRODUCTION -> baseUrlPrefix?.baseUrlPrefixValidator()?.let {
-        "https://$baseUrlPrefix.api.checkout.com/tokens"
-    } ?: PRODUCTION_SERVER_URL
-    Environment.SANDBOX -> baseUrlPrefix?.baseUrlPrefixValidator()?.let {
-        "https://$baseUrlPrefix.api.sandbox.checkout.com/tokens"
-    } ?: SANDBOX_SERVER_URL
+    Environment.PRODUCTION -> PRODUCTION_SERVER_URL.applyPrefix(baseUrlPrefix)
+    Environment.SANDBOX -> SANDBOX_SERVER_URL.applyPrefix(baseUrlPrefix)
 }
 internal fun Environment.toLoggingEnvironment() = when (this) {
     Environment.PRODUCTION -> com.checkout.eventlogger.Environment.PRODUCTION
@@ -18,14 +17,16 @@ internal fun Environment.toLoggingEnvironment() = when (this) {
 }
 
 internal fun Environment.toLoggingName() = when (this) {
-    Environment.PRODUCTION ->
-        "production"
-    Environment.SANDBOX ->
-        "sandbox"
+    Environment.PRODUCTION -> PRODUCTION_LOGGING
+    Environment.SANDBOX -> SANDBOX_LOGGING
+}
+
+private fun String.applyPrefix(prefix: String?): String {
+    val validatedPrefix = prefix?.baseUrlPrefixValidator() ?: return this
+    return this.replace(HTTPS_PROTOCOL, "$HTTPS_PROTOCOL$validatedPrefix.")
 }
 
 private fun String?.baseUrlPrefixValidator() = this
-    ?.takeIf {
-            prefix ->
-        prefix.all { char -> char.isLetterOrDigit() } && prefix.isNotEmpty()
+    ?.takeIf { prefix ->
+        prefix.all { char -> char in 'a'..'z' || char in 'A'..'Z' || char in '0'..'9' } && prefix.isNotEmpty()
     }

--- a/checkout/src/main/java/com/checkout/logging/utils/EnvironmentExtension.kt
+++ b/checkout/src/main/java/com/checkout/logging/utils/EnvironmentExtension.kt
@@ -1,7 +1,18 @@
 package com.checkout.logging.utils
 
 import com.checkout.base.model.Environment
+import com.checkout.base.util.EnvironmentConstants.PRODUCTION_SERVER_URL
+import com.checkout.base.util.EnvironmentConstants.SANDBOX_SERVER_URL
 
+
+internal fun Environment.toBaseUrl(subDomainPrefix: String? = null) = when(this) {
+    Environment.PRODUCTION -> subDomainPrefix?.filter { it.isLetterOrDigit() }?.let {
+        "https://${subDomainPrefix}.api.checkout.com/tokens"
+    } ?: PRODUCTION_SERVER_URL
+    Environment.SANDBOX -> subDomainPrefix?.filter { it.isLetterOrDigit() }?.let {
+        "https://${subDomainPrefix}.api.sandbox.checkout.com/tokens"
+    } ?: SANDBOX_SERVER_URL
+}
 internal fun Environment.toLoggingEnvironment() = when (this) {
     Environment.PRODUCTION -> com.checkout.eventlogger.Environment.PRODUCTION
     Environment.SANDBOX -> com.checkout.eventlogger.Environment.SANDBOX

--- a/checkout/src/main/java/com/checkout/logging/utils/EnvironmentExtension.kt
+++ b/checkout/src/main/java/com/checkout/logging/utils/EnvironmentExtension.kt
@@ -11,6 +11,7 @@ internal fun Environment.toBaseUrl(baseUrlPrefix: String? = null) = when (this) 
     Environment.PRODUCTION -> PRODUCTION_SERVER_URL.applyPrefix(baseUrlPrefix)
     Environment.SANDBOX -> SANDBOX_SERVER_URL.applyPrefix(baseUrlPrefix)
 }
+
 internal fun Environment.toLoggingEnvironment() = when (this) {
     Environment.PRODUCTION -> com.checkout.eventlogger.Environment.PRODUCTION
     Environment.SANDBOX -> com.checkout.eventlogger.Environment.SANDBOX
@@ -26,7 +27,7 @@ private fun String.applyPrefix(prefix: String?): String {
     return this.replace(HTTPS_PROTOCOL, "$HTTPS_PROTOCOL$validatedPrefix.")
 }
 
-private fun String?.baseUrlPrefixValidator() = this
-    ?.takeIf { prefix ->
-        prefix.all { char -> char in 'a'..'z' || char in 'A'..'Z' || char in '0'..'9' } && prefix.isNotEmpty()
+private fun String.baseUrlPrefixValidator() = this
+    .takeIf { prefix ->
+        prefix.isNotEmpty() && prefix.all { char -> char in 'a'..'z' || char in 'A'..'Z' || char in '0'..'9' }
     }

--- a/checkout/src/main/java/com/checkout/logging/utils/EnvironmentExtension.kt
+++ b/checkout/src/main/java/com/checkout/logging/utils/EnvironmentExtension.kt
@@ -24,7 +24,8 @@ internal fun Environment.toLoggingName() = when (this) {
         "sandbox"
 }
 
-private fun String?.baseUrlPrefixValidator() = this?.takeIf {
-    prefix ->
-    prefix.all { char -> char.isLetterOrDigit() } && prefix.isNotEmpty()
-}
+private fun String?.baseUrlPrefixValidator() = this
+    ?.takeIf {
+            prefix ->
+        prefix.all { char -> char.isLetterOrDigit() } && prefix.isNotEmpty()
+    }

--- a/checkout/src/main/java/com/checkout/logging/utils/EnvironmentExtension.kt
+++ b/checkout/src/main/java/com/checkout/logging/utils/EnvironmentExtension.kt
@@ -5,12 +5,12 @@ import com.checkout.base.util.EnvironmentConstants.PRODUCTION_SERVER_URL
 import com.checkout.base.util.EnvironmentConstants.SANDBOX_SERVER_URL
 
 
-internal fun Environment.toBaseUrl(subDomainPrefix: String? = null) = when(this) {
-    Environment.PRODUCTION -> subDomainPrefix?.filter { it.isLetterOrDigit() }?.let {
-        "https://${subDomainPrefix}.api.checkout.com/tokens"
+internal fun Environment.toBaseUrl(baseUrlPrefix: String? = null) = when(this) {
+    Environment.PRODUCTION -> baseUrlPrefix?.baseUrlPrefixValidator()?.let {
+        "https://${baseUrlPrefix}.api.checkout.com/tokens"
     } ?: PRODUCTION_SERVER_URL
-    Environment.SANDBOX -> subDomainPrefix?.filter { it.isLetterOrDigit() }?.let {
-        "https://${subDomainPrefix}.api.sandbox.checkout.com/tokens"
+    Environment.SANDBOX -> baseUrlPrefix?.baseUrlPrefixValidator()?.let {
+        "https://${baseUrlPrefix}.api.sandbox.checkout.com/tokens"
     } ?: SANDBOX_SERVER_URL
 }
 internal fun Environment.toLoggingEnvironment() = when (this) {
@@ -21,4 +21,8 @@ internal fun Environment.toLoggingEnvironment() = when (this) {
 internal fun Environment.toLoggingName() = when (this) {
     Environment.PRODUCTION -> "production"
     Environment.SANDBOX -> "sandbox"
+}
+
+private fun String?.baseUrlPrefixValidator() = this?.takeIf {
+    prefix -> prefix.all { char -> char.isLetterOrDigit() } && prefix.isNotEmpty()
 }

--- a/checkout/src/test/java/com/checkout/CheckoutApiServiceFactoryTest.kt
+++ b/checkout/src/test/java/com/checkout/CheckoutApiServiceFactoryTest.kt
@@ -34,7 +34,7 @@ internal class CheckoutApiServiceFactoryTest {
         val mockEnvironment = Environment.SANDBOX
 
         // When
-        CheckoutApiServiceFactory.create("", mockEnvironment, mockContext)
+        CheckoutApiServiceFactory.create("", mockEnvironment, mockContext, null)
 
         // Then
         verify { mockLogger.setup(eq(mockContext), eq(mockEnvironment)) }

--- a/checkout/src/test/java/com/checkout/EnvironmentExtensionTest.kt
+++ b/checkout/src/test/java/com/checkout/EnvironmentExtensionTest.kt
@@ -63,6 +63,7 @@ internal class EnvironmentExtensionTest {
         assertEquals("https://api.checkout.com/tokens", result)
     }
 
+    @Test
     fun `toBaseUrl PRODUCTION returns default URL for any non-alphanumeric prefix`() {
         val invalidPrefixList = listOf(
             "invalid_prefix",
@@ -81,11 +82,11 @@ internal class EnvironmentExtensionTest {
             "invalid prefix",
         )
 
-        invalidPrefixList.map { invalidPrefix ->
+        invalidPrefixList.forEach { invalidPrefix ->
             val result = Environment.PRODUCTION.toBaseUrl(invalidPrefix)
             assertEquals(
-                result,
                 PRODUCTION_SERVER_URL,
+                result
             )
         }
     }

--- a/checkout/src/test/java/com/checkout/EnvironmentExtensionTest.kt
+++ b/checkout/src/test/java/com/checkout/EnvironmentExtensionTest.kt
@@ -86,7 +86,7 @@ internal class EnvironmentExtensionTest {
             val result = Environment.PRODUCTION.toBaseUrl(invalidPrefix)
             assertEquals(
                 PRODUCTION_SERVER_URL,
-                result
+                result,
             )
         }
     }

--- a/checkout/src/test/java/com/checkout/EnvironmentExtensionTest.kt
+++ b/checkout/src/test/java/com/checkout/EnvironmentExtensionTest.kt
@@ -78,14 +78,14 @@ internal class EnvironmentExtensionTest {
             "invalid*prefix",
             "invalid(prefix",
             "invalid)prefix",
-            "invalid prefix"
+            "invalid prefix",
         )
 
         invalidPrefixList.map { invalidPrefix ->
             val result = Environment.PRODUCTION.toBaseUrl(invalidPrefix)
             assertEquals(
                 result,
-                PRODUCTION_SERVER_URL
+                PRODUCTION_SERVER_URL,
             )
         }
     }

--- a/checkout/src/test/java/com/checkout/EnvironmentExtensionTest.kt
+++ b/checkout/src/test/java/com/checkout/EnvironmentExtensionTest.kt
@@ -1,0 +1,92 @@
+package com.checkout
+
+import com.checkout.base.model.Environment
+import com.checkout.base.util.EnvironmentConstants
+import com.checkout.base.util.EnvironmentConstants.PRODUCTION_SERVER_URL
+import com.checkout.logging.utils.toBaseUrl
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class EnvironmentExtensionTest {
+
+    @Test
+    fun `when toBaseUrl PRODUCTION with null subDomainPrefix returns production server URL`() {
+        val result = Environment.PRODUCTION.toBaseUrl(null)
+        assertEquals(EnvironmentConstants.PRODUCTION_SERVER_URL, result)
+    }
+
+    @Test
+    fun `when toBaseUrl PRODUCTION with no subDomainPrefix argument returns production server URL`() {
+        val result = Environment.PRODUCTION.toBaseUrl()
+        assertEquals(EnvironmentConstants.PRODUCTION_SERVER_URL, result)
+    }
+
+    @Test
+    fun `when toBaseUrl PRODUCTION with subDomainPrefix returns custom production URL`() {
+        val result = Environment.PRODUCTION.toBaseUrl("custom")
+        assertEquals("https://custom.api.checkout.com/tokens", result)
+    }
+
+    @Test
+    fun `when toBaseUrl PRODUCTION with alphanumeric subDomainPrefix returns custom production URL`() {
+        val result = Environment.PRODUCTION.toBaseUrl("mySubdomain123")
+        assertEquals("https://mySubdomain123.api.checkout.com/tokens", result)
+    }
+
+    @Test
+    fun `when toBaseUrl SANDBOX with null subDomainPrefix returns sandbox server URL`() {
+        val result = Environment.SANDBOX.toBaseUrl(null)
+        assertEquals(EnvironmentConstants.SANDBOX_SERVER_URL, result)
+    }
+
+    @Test
+    fun `when toBaseUrl SANDBOX with no subDomainPrefix argument returns sandbox server URL`() {
+        val result = Environment.SANDBOX.toBaseUrl()
+        assertEquals(EnvironmentConstants.SANDBOX_SERVER_URL, result)
+    }
+
+    @Test
+    fun `when toBaseUrl SANDBOX with subDomainPrefix returns custom sandbox URL`() {
+        val result = Environment.SANDBOX.toBaseUrl("custom")
+        assertEquals("https://custom.api.sandbox.checkout.com/tokens", result)
+    }
+
+    @Test
+    fun `when toBaseUrl SANDBOX with alphanumeric subDomainPrefix returns custom sandbox URL`() {
+        val result = Environment.SANDBOX.toBaseUrl("test99")
+        assertEquals("https://test99.api.sandbox.checkout.com/tokens", result)
+    }
+
+    @Test
+    fun `when toBaseUrl with empty string subDomainPrefix uses default URL for production`() {
+        val result = Environment.PRODUCTION.toBaseUrl("")
+        assertEquals("https://api.checkout.com/tokens", result)
+    }
+
+    fun `toBaseUrl PRODUCTION returns default URL for any non-alphanumeric prefix`() {
+        val invalidPrefixList = listOf(
+            "invalid_prefix",
+            "invalid-prefix",
+            "invalid.prefix",
+            "invalid@prefix",
+            "invalid!prefix",
+            "invalid#prefix",
+            "invalid\$prefix",
+            "invalid%prefix",
+            "invalid^prefix",
+            "invalid&prefix",
+            "invalid*prefix",
+            "invalid(prefix",
+            "invalid)prefix",
+            "invalid prefix"
+        )
+
+        invalidPrefixList.map { invalidPrefix ->
+            val result = Environment.PRODUCTION.toBaseUrl(invalidPrefix)
+            assertEquals(
+                result,
+                PRODUCTION_SERVER_URL
+            )
+        }
+    }
+}

--- a/example_app_frames/build.gradle.kts
+++ b/example_app_frames/build.gradle.kts
@@ -18,17 +18,17 @@ android {
             buildConfigField(
                 "String",
                 "SANDBOX_PUBLIC_KEY",
-                this["sandbox.components.public_key"].toString(),
+                "\"${this["sandbox.components.public_key"]}\"",
             )
             buildConfigField(
                 "String",
                 "SANDBOX_SECRET_KEY",
-                this["sandbox.components.secret_key"].toString(),
+                "\"${this["sandbox.components.secret_key"]}\"",
             )
             buildConfigField(
                 "String",
                 "SANDBOX_PROCESSING_CHANNEL_ID",
-                this["sandbox.components.processing_channel_id"].toString(),
+                "\"${this["sandbox.components.processing_channel_id"]}\"",
             )
         }
     }

--- a/example_app_frames/build.gradle.kts
+++ b/example_app_frames/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     id("precompiled-android-app")
     id("org.jetbrains.kotlin.plugin.compose")
@@ -9,6 +11,26 @@ android {
         applicationId = ExampleAppFramesConfig.id
         versionCode = ExampleAppFramesConfig.versionCode
         versionName = ExampleAppFramesConfig.versionName
+
+        Properties().apply {
+            load(rootProject.file("local.properties").inputStream())
+        }.run {
+            buildConfigField(
+                "String",
+                "SANDBOX_PUBLIC_KEY",
+                this["sandbox.components.public_key"].toString(),
+            )
+            buildConfigField(
+                "String",
+                "SANDBOX_SECRET_KEY",
+                this["sandbox.components.secret_key"].toString(),
+            )
+            buildConfigField(
+                "String",
+                "SANDBOX_PROCESSING_CHANNEL_ID",
+                this["sandbox.components.processing_channel_id"].toString(),
+            )
+        }
     }
 
     buildTypes {
@@ -19,6 +41,10 @@ android {
                 "proguard-rules.pro",
             )
         }
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 
     packaging {

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/CVVTokenizationScreen.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/CVVTokenizationScreen.kt
@@ -35,6 +35,7 @@ fun CVVTokenizationScreen(navController: NavHostController) {
         publicKey = PUBLIC_KEY_CVV_TOKENIZATION,
         environment = Environment.SANDBOX,
         context = LocalContext.current,
+        regionalSubdomain = "devices"
     )
 
     val visaMediator = createMediator(

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/CVVTokenizationScreen.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/CVVTokenizationScreen.kt
@@ -11,6 +11,7 @@ import com.checkout.base.model.Environment
 import com.checkout.example.frames.paymentformstyling.PaymentFormConstants
 import com.checkout.example.frames.styling.CustomCVVInputFieldStyle
 import com.checkout.example.frames.ui.utils.PUBLIC_KEY_CVV_TOKENIZATION
+import com.checkout.example.frames.ui.utils.REGIONAL_SUBDOMAIN
 import com.checkout.example.frames.ui.viewmodel.CVVTokenizationViewModel
 import com.checkout.frames.cvvinputfield.CVVComponentApiFactory
 import com.checkout.frames.cvvinputfield.api.CVVComponentApi
@@ -35,7 +36,7 @@ fun CVVTokenizationScreen(navController: NavHostController) {
         publicKey = PUBLIC_KEY_CVV_TOKENIZATION,
         environment = Environment.SANDBOX,
         context = LocalContext.current,
-        regionalSubdomain = "devices"
+        baseURLPrefix = REGIONAL_SUBDOMAIN
     )
 
     val visaMediator = createMediator(

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/CVVTokenizationScreen.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/CVVTokenizationScreen.kt
@@ -8,9 +8,9 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import com.checkout.base.model.CardScheme
 import com.checkout.base.model.Environment
+import com.checkout.example.frames.BuildConfig
 import com.checkout.example.frames.paymentformstyling.PaymentFormConstants
 import com.checkout.example.frames.styling.CustomCVVInputFieldStyle
-import com.checkout.example.frames.ui.utils.PUBLIC_KEY_CVV_TOKENIZATION
 import com.checkout.example.frames.ui.utils.REGIONAL_SUBDOMAIN
 import com.checkout.example.frames.ui.viewmodel.CVVTokenizationViewModel
 import com.checkout.frames.cvvinputfield.CVVComponentApiFactory
@@ -33,7 +33,7 @@ fun CVVTokenizationScreen(navController: NavHostController) {
     val cvvTokenizationViewModel: CVVTokenizationViewModel = viewModel()
 
     val cvvComponentApi = CVVComponentApiFactory.create(
-        publicKey = PUBLIC_KEY_CVV_TOKENIZATION,
+        publicKey = BuildConfig.SANDBOX_PUBLIC_KEY,
         environment = Environment.SANDBOX,
         context = LocalContext.current,
         baseUrlPrefix = REGIONAL_SUBDOMAIN,

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/CVVTokenizationScreen.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/CVVTokenizationScreen.kt
@@ -36,7 +36,7 @@ fun CVVTokenizationScreen(navController: NavHostController) {
         publicKey = PUBLIC_KEY_CVV_TOKENIZATION,
         environment = Environment.SANDBOX,
         context = LocalContext.current,
-        baseUrlPrefix = REGIONAL_SUBDOMAIN
+        baseUrlPrefix = REGIONAL_SUBDOMAIN,
     )
 
     val visaMediator = createMediator(

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/CVVTokenizationScreen.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/CVVTokenizationScreen.kt
@@ -36,7 +36,7 @@ fun CVVTokenizationScreen(navController: NavHostController) {
         publicKey = PUBLIC_KEY_CVV_TOKENIZATION,
         environment = Environment.SANDBOX,
         context = LocalContext.current,
-        baseURLPrefix = REGIONAL_SUBDOMAIN
+        baseUrlPrefix = REGIONAL_SUBDOMAIN
     )
 
     val visaMediator = createMediator(

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/HomeScreen.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/HomeScreen.kt
@@ -223,6 +223,7 @@ fun invokeCheckoutSDKToGenerateTokenForGooglePay(context: Context) {
         "pk_test_6e40a700-d563-43cd-89d0-f9bb17d35e73",
         Environment.SANDBOX,
         context,
+        "devices"
     )
 
     /**

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/HomeScreen.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/HomeScreen.kt
@@ -47,6 +47,7 @@ import com.checkout.example.frames.ui.theme.FramesTheme
 import com.checkout.example.frames.ui.theme.GrayColor
 import com.checkout.example.frames.ui.utils.PromptUtils
 import com.checkout.example.frames.ui.utils.PromptUtils.neutralButton
+import com.checkout.example.frames.ui.utils.REGIONAL_SUBDOMAIN
 import com.checkout.tokenization.model.GooglePayTokenRequest
 
 @Suppress("MagicNumber", "LongMethod")
@@ -223,7 +224,7 @@ fun invokeCheckoutSDKToGenerateTokenForGooglePay(context: Context) {
         "pk_test_6e40a700-d563-43cd-89d0-f9bb17d35e73",
         Environment.SANDBOX,
         context,
-        "devices"
+        REGIONAL_SUBDOMAIN,
     )
 
     /**

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/HomeScreen.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/HomeScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.checkout.CheckoutApiServiceFactory
 import com.checkout.base.model.Environment
+import com.checkout.example.frames.BuildConfig
 import com.checkout.example.frames.R
 import com.checkout.example.frames.navigation.Screen
 import com.checkout.example.frames.ui.component.ButtonComponent
@@ -221,7 +222,7 @@ fun invokeCheckoutSDKToGenerateTokenForGooglePay(context: Context) {
      * Creating instance of CheckoutApiClient
      */
     val checkoutApiClient = CheckoutApiServiceFactory.create(
-        "pk_test_6e40a700-d563-43cd-89d0-f9bb17d35e73",
+        BuildConfig.SANDBOX_PUBLIC_KEY,
         Environment.SANDBOX,
         context,
         REGIONAL_SUBDOMAIN,

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/MainActivity.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/MainActivity.kt
@@ -9,13 +9,13 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.checkout.base.model.CardScheme
+import com.checkout.example.frames.BuildConfig
 import com.checkout.example.frames.R
 import com.checkout.example.frames.navigation.Screen
 import com.checkout.example.frames.paymentformstyling.CustomBillingFormStyle
 import com.checkout.example.frames.paymentformstyling.CustomPaymentDetailsStyle
 import com.checkout.example.frames.paymentformstyling.CustomPaymentFormTheme
 import com.checkout.example.frames.ui.utils.ENVIRONMENT
-import com.checkout.example.frames.ui.utils.PUBLIC_KEY
 import com.checkout.example.frames.ui.utils.PrefillDataHelper
 import com.checkout.example.frames.ui.utils.REGIONAL_SUBDOMAIN
 import com.checkout.frames.api.PaymentFlowHandler
@@ -48,7 +48,7 @@ fun Navigator(
 ) {
     val navController = rememberNavController()
     val defaultPaymentFormConfig = PaymentFormConfig(
-        publicKey = PUBLIC_KEY,
+        publicKey = BuildConfig.SANDBOX_PUBLIC_KEY,
         context = context,
         environment = ENVIRONMENT,
         baseUrlPrefix = REGIONAL_SUBDOMAIN,

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/MainActivity.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/MainActivity.kt
@@ -17,6 +17,7 @@ import com.checkout.example.frames.paymentformstyling.CustomPaymentFormTheme
 import com.checkout.example.frames.ui.utils.ENVIRONMENT
 import com.checkout.example.frames.ui.utils.PUBLIC_KEY
 import com.checkout.example.frames.ui.utils.PrefillDataHelper
+import com.checkout.example.frames.ui.utils.REGIONAL_SUBDOMAIN
 import com.checkout.frames.api.PaymentFlowHandler
 import com.checkout.frames.api.PaymentFormMediator
 import com.checkout.frames.screen.paymentform.model.PaymentFormConfig
@@ -50,7 +51,7 @@ fun Navigator(
         publicKey = PUBLIC_KEY,
         context = context,
         environment = ENVIRONMENT,
-        regionalSubdomain = null,
+        baseURLPrefix = REGIONAL_SUBDOMAIN,
         paymentFlowHandler = object : PaymentFlowHandler {
             override fun onSubmit() {
                 /*Intentionally left empty*/

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/MainActivity.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/MainActivity.kt
@@ -51,7 +51,7 @@ fun Navigator(
         publicKey = PUBLIC_KEY,
         context = context,
         environment = ENVIRONMENT,
-        baseURLPrefix = REGIONAL_SUBDOMAIN,
+        baseUrlPrefix = REGIONAL_SUBDOMAIN,
         paymentFlowHandler = object : PaymentFlowHandler {
             override fun onSubmit() {
                 /*Intentionally left empty*/

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/MainActivity.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/MainActivity.kt
@@ -50,6 +50,7 @@ fun Navigator(
         publicKey = PUBLIC_KEY,
         context = context,
         environment = ENVIRONMENT,
+        regionalSubdomain = null,
         paymentFlowHandler = object : PaymentFlowHandler {
             override fun onSubmit() {
                 /*Intentionally left empty*/

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/ThreedSecureActivity.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/screen/ThreedSecureActivity.kt
@@ -4,10 +4,10 @@ import android.os.Bundle
 import android.view.ViewGroup
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import com.checkout.example.frames.BuildConfig
 import com.checkout.example.frames.R
 import com.checkout.example.frames.ui.utils.ENVIRONMENT
 import com.checkout.example.frames.ui.utils.FAILURE_URL
-import com.checkout.example.frames.ui.utils.PUBLIC_KEY
 import com.checkout.example.frames.ui.utils.PromptUtils
 import com.checkout.example.frames.ui.utils.PromptUtils.neutralButton
 import com.checkout.example.frames.ui.utils.SUCCESS_URL
@@ -28,7 +28,7 @@ class ThreedSecureActivity : ComponentActivity() {
             val url = intent.getStringExtra(URL_IDENTIFIER)
 
             val paymentFormConfig = PaymentFormConfig(
-                publicKey = PUBLIC_KEY,
+                publicKey = BuildConfig.SANDBOX_PUBLIC_KEY,
                 context = this,
                 environment = ENVIRONMENT,
                 paymentFlowHandler = object : PaymentFlowHandler {

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/utils/Constants.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/utils/Constants.kt
@@ -10,17 +10,22 @@ val ENVIRONMENT: Environment = Environment.SANDBOX
 /**
  * Replace with public key from Hub in Sandbox Environment
  */
-const val PUBLIC_KEY = "pk_test_b37b8b6b-fc9a-483f-a77e-3386b606f90e"
+const val PUBLIC_KEY = "pk_sbox_dheqoi7tqn2jcvbn55sa2czwu42"
 
 /**
  * Replace with public key from Hub in Sandbox Environment, testing key for CVV Tokenization
  */
-const val PUBLIC_KEY_CVV_TOKENIZATION = "pk_6b30805a-1f3b-4c63-8b75-eb3030109173"
+const val PUBLIC_KEY_CVV_TOKENIZATION = "pk_sbox_dheqoi7tqn2jcvbn55sa2czwu42"
+
+/**
+ * Replace with subdomain value, testing key for base url regional subdomain prefix
+ */
+const val REGIONAL_SUBDOMAIN = "global"
 
 /**
  * Replace with Secret key from Hub in Sandbox Environment
  */
-const val SECRET_KEY = "sk_test_568e6077-a08f-4692-9237-cc6c48dcf6aa"
+const val SECRET_KEY = "sk_sbox_cqc26o3haljkwuns6xcfcmf2vmu"
 
 /**
  * Replace with Success/Failure Urls from Hub in Sandbox Environment

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/utils/Constants.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/utils/Constants.kt
@@ -8,16 +8,6 @@ import com.checkout.base.model.Environment
 val ENVIRONMENT: Environment = Environment.SANDBOX
 
 /**
- * Replace with public key from Hub in Sandbox Environment
- */
-const val PUBLIC_KEY = "pk_sbox_dheqoi7tqn2jcvbn55sa2czwu42"
-
-/**
- * Replace with public key from Hub in Sandbox Environment, testing key for CVV Tokenization
- */
-const val PUBLIC_KEY_CVV_TOKENIZATION = "pk_sbox_dheqoi7tqn2jcvbn55sa2czwu42"
-
-/**
  * Replace with subdomain value, testing key for base url regional subdomain prefix
  */
 const val REGIONAL_SUBDOMAIN = "global"

--- a/example_app_frames/src/main/java/com/checkout/example/frames/ui/utils/Constants.kt
+++ b/example_app_frames/src/main/java/com/checkout/example/frames/ui/utils/Constants.kt
@@ -23,11 +23,6 @@ const val PUBLIC_KEY_CVV_TOKENIZATION = "pk_sbox_dheqoi7tqn2jcvbn55sa2czwu42"
 const val REGIONAL_SUBDOMAIN = "global"
 
 /**
- * Replace with Secret key from Hub in Sandbox Environment
- */
-const val SECRET_KEY = "sk_sbox_cqc26o3haljkwuns6xcfcmf2vmu"
-
-/**
  * Replace with Success/Failure Urls from Hub in Sandbox Environment
  */
 const val SUCCESS_URL = "https://httpstat.us/200?q=Success"

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/CVVComponentApiFactory.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/CVVComponentApiFactory.kt
@@ -16,13 +16,14 @@ public object CVVComponentApiFactory {
      * @param publicKey - used for client-side authentication in the SDK
      * @param environment - [Environment] represent the environment for tokenization
      * @param context - represent the application context
+     * @param baseUrlPrefix -  an optional alphanumeric prefix used to route requests to a specific regional or merchant-specific subdomain (e.g., "msdd"). Must be alphanumeric.
      */
     @JvmStatic
     public fun create(
         publicKey: String,
         environment: Environment,
         context: Context,
-        baseUrlPrefix: String?,
+        baseUrlPrefix: String? = null,
     ): CVVComponentApi {
         return InternalCVVComponentApi(publicKey, environment, context, baseUrlPrefix)
     }

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/CVVComponentApiFactory.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/CVVComponentApiFactory.kt
@@ -22,7 +22,8 @@ public object CVVComponentApiFactory {
         publicKey: String,
         environment: Environment,
         context: Context,
+        regionalSubdomain: String,
     ): CVVComponentApi {
-        return InternalCVVComponentApi(publicKey, environment, context)
+        return InternalCVVComponentApi(publicKey, environment, context, regionalSubdomain)
     }
 }

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/CVVComponentApiFactory.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/CVVComponentApiFactory.kt
@@ -22,8 +22,8 @@ public object CVVComponentApiFactory {
         publicKey: String,
         environment: Environment,
         context: Context,
-        baseURLPrefix: String,
+        baseUrlPrefix: String?,
     ): CVVComponentApi {
-        return InternalCVVComponentApi(publicKey, environment, context, baseURLPrefix)
+        return InternalCVVComponentApi(publicKey, environment, context, baseUrlPrefix)
     }
 }

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/CVVComponentApiFactory.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/CVVComponentApiFactory.kt
@@ -16,7 +16,7 @@ public object CVVComponentApiFactory {
      * @param publicKey - used for client-side authentication in the SDK
      * @param environment - [Environment] represent the environment for tokenization
      * @param context - represent the application context
-     * @param baseUrlPrefix -  an optional alphanumeric prefix used to route requests to a specific regional or merchant-specific subdomain (e.g., "msdd"). Must be alphanumeric.
+     * @param baseUrlPrefix - an optional alphanumeric prefix used to route requests to a specific regional or merchant-specific subdomain (e.g., "msdd"). Must be alphanumeric.
      */
     @JvmStatic
     public fun create(

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/CVVComponentApiFactory.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/CVVComponentApiFactory.kt
@@ -22,8 +22,8 @@ public object CVVComponentApiFactory {
         publicKey: String,
         environment: Environment,
         context: Context,
-        regionalSubdomain: String,
+        baseURLPrefix: String,
     ): CVVComponentApi {
-        return InternalCVVComponentApi(publicKey, environment, context, regionalSubdomain)
+        return InternalCVVComponentApi(publicKey, environment, context, baseURLPrefix)
     }
 }

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/api/InternalCVVComponentApi.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/api/InternalCVVComponentApi.kt
@@ -10,7 +10,7 @@ internal class InternalCVVComponentApi(
     private val publicKey: String,
     private val environment: Environment,
     private val context: Context,
-    private val baseUrlPrefix: String?
+    private val baseUrlPrefix: String?,
 ) : CVVComponentApi {
 
     override fun createComponentMediator(cvvComponentConfig: CVVComponentConfig) = InternalCVVComponentMediator(
@@ -20,7 +20,7 @@ internal class InternalCVVComponentApi(
                 publicKey = publicKey,
                 environment = environment,
                 context = context,
-                baseUrlPrefix = baseUrlPrefix
+                baseUrlPrefix = baseUrlPrefix,
             ),
         ),
     )

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/api/InternalCVVComponentApi.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/api/InternalCVVComponentApi.kt
@@ -10,6 +10,7 @@ internal class InternalCVVComponentApi(
     private val publicKey: String,
     private val environment: Environment,
     private val context: Context,
+    private val regionalSubdomain: String
 ) : CVVComponentApi {
 
     override fun createComponentMediator(cvvComponentConfig: CVVComponentConfig) = InternalCVVComponentMediator(
@@ -19,6 +20,7 @@ internal class InternalCVVComponentApi(
                 publicKey = publicKey,
                 environment = environment,
                 context = context,
+                regionalSubdomain = regionalSubdomain
             ),
         ),
     )

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/api/InternalCVVComponentApi.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/api/InternalCVVComponentApi.kt
@@ -10,7 +10,7 @@ internal class InternalCVVComponentApi(
     private val publicKey: String,
     private val environment: Environment,
     private val context: Context,
-    private val baseURLPrefix: String?
+    private val baseUrlPrefix: String?
 ) : CVVComponentApi {
 
     override fun createComponentMediator(cvvComponentConfig: CVVComponentConfig) = InternalCVVComponentMediator(
@@ -20,7 +20,7 @@ internal class InternalCVVComponentApi(
                 publicKey = publicKey,
                 environment = environment,
                 context = context,
-                baseURLPrefix = baseURLPrefix
+                baseUrlPrefix = baseUrlPrefix
             ),
         ),
     )

--- a/frames/src/main/java/com/checkout/frames/cvvinputfield/api/InternalCVVComponentApi.kt
+++ b/frames/src/main/java/com/checkout/frames/cvvinputfield/api/InternalCVVComponentApi.kt
@@ -10,7 +10,7 @@ internal class InternalCVVComponentApi(
     private val publicKey: String,
     private val environment: Environment,
     private val context: Context,
-    private val regionalSubdomain: String
+    private val baseURLPrefix: String?
 ) : CVVComponentApi {
 
     override fun createComponentMediator(cvvComponentConfig: CVVComponentConfig) = InternalCVVComponentMediator(
@@ -20,7 +20,7 @@ internal class InternalCVVComponentApi(
                 publicKey = publicKey,
                 environment = environment,
                 context = context,
-                regionalSubdomain = regionalSubdomain
+                baseURLPrefix = baseURLPrefix
             ),
         ),
     )

--- a/frames/src/main/java/com/checkout/frames/di/component/FramesDIComponent.kt
+++ b/frames/src/main/java/com/checkout/frames/di/component/FramesDIComponent.kt
@@ -69,7 +69,7 @@ internal abstract class FramesDIComponent {
         fun prefillData(cardHolderName: PrefillData?): Builder
 
         @BindsInstance
-        fun regionalSubdomain(regionalSubdomain: String?): Builder
+        fun baseURLPrefix(baseURLPrefix: String?): Builder
 
         fun build(): FramesDIComponent
     }

--- a/frames/src/main/java/com/checkout/frames/di/component/FramesDIComponent.kt
+++ b/frames/src/main/java/com/checkout/frames/di/component/FramesDIComponent.kt
@@ -68,6 +68,9 @@ internal abstract class FramesDIComponent {
         @BindsInstance
         fun prefillData(cardHolderName: PrefillData?): Builder
 
+        @BindsInstance
+        fun regionalSubdomain(regionalSubdomain: String?): Builder
+
         fun build(): FramesDIComponent
     }
 }

--- a/frames/src/main/java/com/checkout/frames/di/component/FramesDIComponent.kt
+++ b/frames/src/main/java/com/checkout/frames/di/component/FramesDIComponent.kt
@@ -69,7 +69,7 @@ internal abstract class FramesDIComponent {
         fun prefillData(cardHolderName: PrefillData?): Builder
 
         @BindsInstance
-        fun baseURLPrefix(baseURLPrefix: String?): Builder
+        fun baseUrlPrefix(baseUrlPrefix: String?): Builder
 
         fun build(): FramesDIComponent
     }

--- a/frames/src/main/java/com/checkout/frames/di/injector/FramesInjector.kt
+++ b/frames/src/main/java/com/checkout/frames/di/injector/FramesInjector.kt
@@ -56,8 +56,8 @@ internal class FramesInjector(private val component: FramesDIComponent) : Inject
             environment: Environment,
             paymentFlowHandler: PaymentFlowHandler,
             supportedCardSchemeList: List<CardScheme> = emptyList(),
+            baseURLPrefix: String?,
             prefillData: PrefillData? = null,
-            regionalSubdomain: String? = null
         ): Injector {
             val logger = EventLoggerProvider.provide().apply {
                 setup(context, environment, BuildConfig.LOGGING_IDENTIFIER, BuildConfig.PRODUCT_VERSION)
@@ -65,7 +65,7 @@ internal class FramesInjector(private val component: FramesDIComponent) : Inject
             }
             val closePaymentFlowUseCase = ClosePaymentFlowUseCase(paymentFlowHandler::onBackPressed)
             val cardTokenizationUseCase = CardTokenizationUseCase(
-                CheckoutApiServiceFactory.create(publicKey, environment, context, regionalSubdomain),
+                CheckoutApiServiceFactory.create(publicKey, environment, context, baseURLPrefix),
                 paymentFlowHandler::onSubmit,
                 paymentFlowHandler::onSuccess,
                 paymentFlowHandler::onFailure,
@@ -77,7 +77,7 @@ internal class FramesInjector(private val component: FramesDIComponent) : Inject
                     .closePaymentFlowUseCase(closePaymentFlowUseCase)
                     .supportedCardSchemes(supportedCardSchemeList)
                     .prefillData(prefillData)
-                    .regionalSubdomain(regionalSubdomain)
+                    .baseURLPrefix(baseURLPrefix)
                     .build(),
             )
         }

--- a/frames/src/main/java/com/checkout/frames/di/injector/FramesInjector.kt
+++ b/frames/src/main/java/com/checkout/frames/di/injector/FramesInjector.kt
@@ -56,7 +56,7 @@ internal class FramesInjector(private val component: FramesDIComponent) : Inject
             environment: Environment,
             paymentFlowHandler: PaymentFlowHandler,
             supportedCardSchemeList: List<CardScheme> = emptyList(),
-            baseURLPrefix: String?,
+            baseUrlPrefix: String?,
             prefillData: PrefillData? = null,
         ): Injector {
             val logger = EventLoggerProvider.provide().apply {
@@ -65,7 +65,7 @@ internal class FramesInjector(private val component: FramesDIComponent) : Inject
             }
             val closePaymentFlowUseCase = ClosePaymentFlowUseCase(paymentFlowHandler::onBackPressed)
             val cardTokenizationUseCase = CardTokenizationUseCase(
-                CheckoutApiServiceFactory.create(publicKey, environment, context, baseURLPrefix),
+                CheckoutApiServiceFactory.create(publicKey, environment, context, baseUrlPrefix),
                 paymentFlowHandler::onSubmit,
                 paymentFlowHandler::onSuccess,
                 paymentFlowHandler::onFailure,
@@ -77,7 +77,7 @@ internal class FramesInjector(private val component: FramesDIComponent) : Inject
                     .closePaymentFlowUseCase(closePaymentFlowUseCase)
                     .supportedCardSchemes(supportedCardSchemeList)
                     .prefillData(prefillData)
-                    .baseURLPrefix(baseURLPrefix)
+                    .baseUrlPrefix(baseUrlPrefix)
                     .build(),
             )
         }

--- a/frames/src/main/java/com/checkout/frames/di/injector/FramesInjector.kt
+++ b/frames/src/main/java/com/checkout/frames/di/injector/FramesInjector.kt
@@ -57,6 +57,7 @@ internal class FramesInjector(private val component: FramesDIComponent) : Inject
             paymentFlowHandler: PaymentFlowHandler,
             supportedCardSchemeList: List<CardScheme> = emptyList(),
             prefillData: PrefillData? = null,
+            regionalSubdomain: String? = null
         ): Injector {
             val logger = EventLoggerProvider.provide().apply {
                 setup(context, environment, BuildConfig.LOGGING_IDENTIFIER, BuildConfig.PRODUCT_VERSION)
@@ -64,7 +65,7 @@ internal class FramesInjector(private val component: FramesDIComponent) : Inject
             }
             val closePaymentFlowUseCase = ClosePaymentFlowUseCase(paymentFlowHandler::onBackPressed)
             val cardTokenizationUseCase = CardTokenizationUseCase(
-                CheckoutApiServiceFactory.create(publicKey, environment, context),
+                CheckoutApiServiceFactory.create(publicKey, environment, context, regionalSubdomain),
                 paymentFlowHandler::onSubmit,
                 paymentFlowHandler::onSuccess,
                 paymentFlowHandler::onFailure,
@@ -76,6 +77,7 @@ internal class FramesInjector(private val component: FramesDIComponent) : Inject
                     .closePaymentFlowUseCase(closePaymentFlowUseCase)
                     .supportedCardSchemes(supportedCardSchemeList)
                     .prefillData(prefillData)
+                    .regionalSubdomain(regionalSubdomain)
                     .build(),
             )
         }

--- a/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormScreen.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormScreen.kt
@@ -25,7 +25,7 @@ internal fun PaymentFormScreen(config: PaymentFormConfig) {
             paymentFlowHandler = config.paymentFlowHandler,
             supportedCardSchemes = config.supportedCardSchemeList,
             prefillData = config.prefillData,
-            regionalSubdomain = config.regionalSubdomain
+            baseURLPrefix = config.baseURLPrefix
         ),
     )
 

--- a/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormScreen.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormScreen.kt
@@ -25,7 +25,7 @@ internal fun PaymentFormScreen(config: PaymentFormConfig) {
             paymentFlowHandler = config.paymentFlowHandler,
             supportedCardSchemes = config.supportedCardSchemeList,
             prefillData = config.prefillData,
-            baseUrlPrefix = config.baseUrlPrefix
+            baseUrlPrefix = config.baseUrlPrefix,
         ),
     )
 

--- a/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormScreen.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormScreen.kt
@@ -25,6 +25,7 @@ internal fun PaymentFormScreen(config: PaymentFormConfig) {
             paymentFlowHandler = config.paymentFlowHandler,
             supportedCardSchemes = config.supportedCardSchemeList,
             prefillData = config.prefillData,
+            regionalSubdomain = config.regionalSubdomain
         ),
     )
 

--- a/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormScreen.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormScreen.kt
@@ -25,7 +25,7 @@ internal fun PaymentFormScreen(config: PaymentFormConfig) {
             paymentFlowHandler = config.paymentFlowHandler,
             supportedCardSchemes = config.supportedCardSchemeList,
             prefillData = config.prefillData,
-            baseURLPrefix = config.baseURLPrefix
+            baseUrlPrefix = config.baseUrlPrefix
         ),
     )
 

--- a/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormViewModel.kt
@@ -22,7 +22,7 @@ internal class PaymentFormViewModel @Inject internal constructor() : ViewModel()
         private val environment: Environment,
         private val paymentFlowHandler: PaymentFlowHandler,
         private val supportedCardSchemes: List<CardScheme> = emptyList(),
-        private val baseURLPrefix: String?,
+        private val baseUrlPrefix: String?,
         private val prefillData: PrefillData? = null,
     ) : ViewModelProvider.Factory, InjectionClient {
 
@@ -34,7 +34,7 @@ internal class PaymentFormViewModel @Inject internal constructor() : ViewModel()
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             injector = FramesInjector.create(
-                publicKey, context, environment, paymentFlowHandler, supportedCardSchemes, baseURLPrefix, prefillData,
+                publicKey, context, environment, paymentFlowHandler, supportedCardSchemes, baseUrlPrefix, prefillData,
             )
 
             injector.inject(this)

--- a/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormViewModel.kt
@@ -22,8 +22,8 @@ internal class PaymentFormViewModel @Inject internal constructor() : ViewModel()
         private val environment: Environment,
         private val paymentFlowHandler: PaymentFlowHandler,
         private val supportedCardSchemes: List<CardScheme> = emptyList(),
+        private val baseURLPrefix: String?,
         private val prefillData: PrefillData? = null,
-        private val regionalSubdomain: String? = null,
     ) : ViewModelProvider.Factory, InjectionClient {
 
         @Inject
@@ -34,7 +34,7 @@ internal class PaymentFormViewModel @Inject internal constructor() : ViewModel()
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             injector = FramesInjector.create(
-                publicKey, context, environment, paymentFlowHandler, supportedCardSchemes, prefillData, regionalSubdomain
+                publicKey, context, environment, paymentFlowHandler, supportedCardSchemes, baseURLPrefix, prefillData,
             )
 
             injector.inject(this)

--- a/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormViewModel.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentform/PaymentFormViewModel.kt
@@ -23,6 +23,7 @@ internal class PaymentFormViewModel @Inject internal constructor() : ViewModel()
         private val paymentFlowHandler: PaymentFlowHandler,
         private val supportedCardSchemes: List<CardScheme> = emptyList(),
         private val prefillData: PrefillData? = null,
+        private val regionalSubdomain: String? = null,
     ) : ViewModelProvider.Factory, InjectionClient {
 
         @Inject
@@ -33,7 +34,7 @@ internal class PaymentFormViewModel @Inject internal constructor() : ViewModel()
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             injector = FramesInjector.create(
-                publicKey, context, environment, paymentFlowHandler, supportedCardSchemes, prefillData,
+                publicKey, context, environment, paymentFlowHandler, supportedCardSchemes, prefillData, regionalSubdomain
             )
 
             injector.inject(this)

--- a/frames/src/main/java/com/checkout/frames/screen/paymentform/model/PaymentFormConfig.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentform/model/PaymentFormConfig.kt
@@ -23,4 +23,5 @@ public data class PaymentFormConfig @JvmOverloads constructor(
     public val paymentFlowHandler: PaymentFlowHandler,
     public var supportedCardSchemeList: List<CardScheme> = emptyList(),
     public val prefillData: PrefillData? = null,
+    public val regionalSubdomain: String? = null,
 )

--- a/frames/src/main/java/com/checkout/frames/screen/paymentform/model/PaymentFormConfig.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentform/model/PaymentFormConfig.kt
@@ -14,6 +14,7 @@ import com.checkout.frames.style.screen.PaymentFormStyle
  * @param paymentFlowHandler - [PaymentFlowHandler] represent the handler for PaymentForm
  * @param supportedCardSchemeList - represent the supported card schemes [CardScheme] in PaymentForm
  * @param prefillData - [PrefillData] represent the data for prefill in the PaymentForm
+ * @param baseURLPrefix - a prefix for the base url domain, prefix must be alphanumeric
  */
 public data class PaymentFormConfig @JvmOverloads constructor(
     public val publicKey: String,
@@ -23,5 +24,5 @@ public data class PaymentFormConfig @JvmOverloads constructor(
     public val paymentFlowHandler: PaymentFlowHandler,
     public var supportedCardSchemeList: List<CardScheme> = emptyList(),
     public val prefillData: PrefillData? = null,
-    public val regionalSubdomain: String? = null,
+    public val baseURLPrefix: String? = null,
 )

--- a/frames/src/main/java/com/checkout/frames/screen/paymentform/model/PaymentFormConfig.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentform/model/PaymentFormConfig.kt
@@ -14,7 +14,7 @@ import com.checkout.frames.style.screen.PaymentFormStyle
  * @param paymentFlowHandler - [PaymentFlowHandler] represent the handler for PaymentForm
  * @param supportedCardSchemeList - represent the supported card schemes [CardScheme] in PaymentForm
  * @param prefillData - [PrefillData] represent the data for prefill in the PaymentForm
- * @param baseURLPrefix - a prefix for the base url domain, prefix must be alphanumeric
+ * @param baseURLPrefix - an optional alphanumeric prefix used to route requests to a specific regional or merchant-specific subdomain (e.g., "msdd"). Must be alphanumeric.
  */
 public data class PaymentFormConfig @JvmOverloads constructor(
     public val publicKey: String,

--- a/frames/src/main/java/com/checkout/frames/screen/paymentform/model/PaymentFormConfig.kt
+++ b/frames/src/main/java/com/checkout/frames/screen/paymentform/model/PaymentFormConfig.kt
@@ -14,7 +14,7 @@ import com.checkout.frames.style.screen.PaymentFormStyle
  * @param paymentFlowHandler - [PaymentFlowHandler] represent the handler for PaymentForm
  * @param supportedCardSchemeList - represent the supported card schemes [CardScheme] in PaymentForm
  * @param prefillData - [PrefillData] represent the data for prefill in the PaymentForm
- * @param baseURLPrefix - an optional alphanumeric prefix used to route requests to a specific regional or merchant-specific subdomain (e.g., "msdd"). Must be alphanumeric.
+ * @param baseUrlPrefix - an optional alphanumeric prefix used to route requests to a specific regional or merchant-specific subdomain (e.g., "msdd"). Must be alphanumeric.
  */
 public data class PaymentFormConfig @JvmOverloads constructor(
     public val publicKey: String,
@@ -24,5 +24,5 @@ public data class PaymentFormConfig @JvmOverloads constructor(
     public val paymentFlowHandler: PaymentFlowHandler,
     public var supportedCardSchemeList: List<CardScheme> = emptyList(),
     public val prefillData: PrefillData? = null,
-    public val baseURLPrefix: String? = null,
+    public val baseUrlPrefix: String? = null,
 )

--- a/frames/src/test/java/com/checkout/frames/cvvinputfield/CVVComponentApiFactoryTest.kt
+++ b/frames/src/test/java/com/checkout/frames/cvvinputfield/CVVComponentApiFactoryTest.kt
@@ -24,7 +24,7 @@ internal class CVVComponentApiFactoryTest {
     @Test
     fun `when CVVComponentApiFactory is created then InternalCVVComponentApi is correctly created`() {
         // When
-        val cvvComponentApi = CVVComponentApiFactory.create(publicKey, environment, context)
+        val cvvComponentApi = CVVComponentApiFactory.create(publicKey, environment, context, null)
 
         // Then
         assertEquals(InternalCVVComponentApi::class.java, cvvComponentApi.javaClass)

--- a/frames/src/test/java/com/checkout/frames/cvvinputfield/InternalCVVComponentApiTest.kt
+++ b/frames/src/test/java/com/checkout/frames/cvvinputfield/InternalCVVComponentApiTest.kt
@@ -38,7 +38,7 @@ internal class InternalCVVComponentApiTest {
                 publicKey = "your_public_key",
                 environment = Environment.SANDBOX,
                 context = mockContext,
-                baseUrlPrefix = null
+                baseUrlPrefix = null,
             ),
         )
 

--- a/frames/src/test/java/com/checkout/frames/cvvinputfield/InternalCVVComponentApiTest.kt
+++ b/frames/src/test/java/com/checkout/frames/cvvinputfield/InternalCVVComponentApiTest.kt
@@ -38,7 +38,7 @@ internal class InternalCVVComponentApiTest {
                 publicKey = "your_public_key",
                 environment = Environment.SANDBOX,
                 context = mockContext,
-                baseURLPrefix = null
+                baseUrlPrefix = null
             ),
         )
 

--- a/frames/src/test/java/com/checkout/frames/cvvinputfield/InternalCVVComponentApiTest.kt
+++ b/frames/src/test/java/com/checkout/frames/cvvinputfield/InternalCVVComponentApiTest.kt
@@ -38,6 +38,7 @@ internal class InternalCVVComponentApiTest {
                 publicKey = "your_public_key",
                 environment = Environment.SANDBOX,
                 context = mockContext,
+                baseURLPrefix = null
             ),
         )
 

--- a/frames/src/test/java/com/checkout/frames/mock/PaymentFormConfigTestData.kt
+++ b/frames/src/test/java/com/checkout/frames/mock/PaymentFormConfigTestData.kt
@@ -36,6 +36,7 @@ internal object PaymentFormConfigTestData {
     val style = PaymentFormStyle()
     val supportedCardSchemes = listOf(CardScheme.VISA, CardScheme.MAESTRO)
     const val publicKey = "Test key"
+    val baseUrlPrefix = "prefix"
 
     @Suppress("EmptyFunctionBlock")
     val paymentFlowHandler = object : PaymentFlowHandler {

--- a/frames/src/test/java/com/checkout/frames/screen/paymentform/PaymentFormConfigTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/paymentform/PaymentFormConfigTest.kt
@@ -34,6 +34,7 @@ internal class PaymentFormConfigTest {
             style = PaymentFormStyle(),
             supportedCardSchemeList = listOf(CardScheme.VISA, CardScheme.MAESTRO),
             paymentFlowHandler = PaymentFormConfigTestData.paymentFlowHandler,
+            baseUrlPrefix = "prefix",
             prefillData = PrefillData(
                 cardHolderName = "Test Name",
                 billingFormAddress = BillingFormAddress(
@@ -61,6 +62,7 @@ internal class PaymentFormConfigTest {
             assertEquals(PaymentFormConfigTestData.publicKey, publicKey)
             assertEquals(expectedMockContext, context)
             assertEquals(PaymentFormConfigTestData.supportedCardSchemes, supportedCardSchemeList)
+            assertEquals(PaymentFormConfigTestData.baseUrlPrefix, baseUrlPrefix)
 
             prefillData?.billingFormAddress.let { billingFormAddress ->
                 assertEquals(PaymentFormConfigTestData.prefillData.cardHolderName, prefillData?.cardHolderName)

--- a/frames/src/test/java/com/checkout/frames/screen/paymentform/PaymentFormViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/paymentform/PaymentFormViewModelTest.kt
@@ -29,7 +29,7 @@ internal class PaymentFormViewModelTest {
             paymentFlowHandler = PaymentFormConfigTestData.paymentFlowHandler,
             supportedCardSchemes = PaymentFormConfigTestData.supportedCardSchemes,
             prefillData = PaymentFormConfigTestData.prefillData,
-            baseUrlPrefix = null
+            baseUrlPrefix = null,
         )
 
         // When

--- a/frames/src/test/java/com/checkout/frames/screen/paymentform/PaymentFormViewModelTest.kt
+++ b/frames/src/test/java/com/checkout/frames/screen/paymentform/PaymentFormViewModelTest.kt
@@ -29,6 +29,7 @@ internal class PaymentFormViewModelTest {
             paymentFlowHandler = PaymentFormConfigTestData.paymentFlowHandler,
             supportedCardSchemes = PaymentFormConfigTestData.supportedCardSchemes,
             prefillData = PaymentFormConfigTestData.prefillData,
+            baseUrlPrefix = null
         )
 
         // When


### PR DESCRIPTION
## Issue

[PIMOB-4287](https://checkout.atlassian.net/browse/PIMOB-4287)

## Proposed changes

Added `baseUrlPrefix` as a parameter for Frames configuration
- Example app subdomain base url now uses 'global'
- If baseUrlPrefix's sub domain is not alphanumeric then we do not accept it and we use the standard environment set URL without a prefix.
- PK + SK has been updated.

## Test Steps

1. Pay with via card or via CVV
2. Observe API call being made from global subdomain.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [ ] Reviewers assigned
* [ ] I have performed a self-review of my code and manual testing
* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)

## Further comments

https://github.com/user-attachments/assets/90eccfcf-6258-43bd-9b15-12c68e019713


[PIMOB-4287]: https://checkout.atlassian.net/browse/PIMOB-4287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ